### PR TITLE
feat: API-05 ユーザーマスタのOpenAPI定義

### DIFF
--- a/openapi/wms-api.yaml
+++ b/openapi/wms-api.yaml
@@ -26,6 +26,8 @@ tags:
     description: 取引先マスタ
   - name: master-product
     description: 商品マスタ
+  - name: master-user
+    description: ユーザーマスタ
 
 paths:
   # ============================================================
@@ -1723,6 +1725,310 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
 
+  # ============================================================
+  # MASTER-USER - ユーザーマスタ
+  # ============================================================
+
+  /api/v1/master/users:
+    get:
+      operationId: listUsers
+      summary: ユーザー一覧取得
+      description: |
+        システムに登録されている全ユーザーをページング形式で取得する。
+        キーワード・ロール・ステータスでの絞り込み検索に対応する。
+        SYSTEM_ADMINのみアクセス可能。
+      tags: [master-user]
+      parameters:
+        - name: keyword
+          in: query
+          schema:
+            type: string
+          description: ユーザーコードまたは氏名で部分一致検索（大文字小文字不問）
+        - name: role
+          in: query
+          schema:
+            $ref: '#/components/schemas/UserRole'
+          description: ロール絞り込み
+        - name: status
+          in: query
+          schema:
+            $ref: '#/components/schemas/UserStatus'
+          description: ステータス絞り込み
+        - name: all
+          in: query
+          schema:
+            type: boolean
+          description: trueの場合ページングなしで全件返却
+        - $ref: '#/components/parameters/PageParam'
+        - $ref: '#/components/parameters/SizeParam'
+        - name: sort
+          in: query
+          schema:
+            type: string
+            default: createdAt,desc
+          description: ソート指定（例：userCode,asc / fullName,desc）
+      responses:
+        '200':
+          description: ユーザー一覧
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserPageResponse'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+    post:
+      operationId: createUser
+      summary: ユーザー登録
+      description: |
+        新規ユーザーを登録する。初期パスワードをBCryptでハッシュ化して保存し、
+        初回ログイン時にパスワード変更を強制するフラグをtrueにセットする。
+        SYSTEM_ADMINのみアクセス可能。
+      tags: [master-user]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateUserRequest'
+      responses:
+        '201':
+          description: 登録成功
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserDetail'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          description: ユーザーコード重複
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                duplicateCode:
+                  summary: ユーザーコード重複
+                  value:
+                    errorCode: DUPLICATE_CODE
+                    message: 指定されたユーザーコードはすでに登録されています
+
+  /api/v1/master/users/{id}:
+    get:
+      operationId: getUser
+      summary: ユーザー取得
+      description: 指定されたIDのユーザーを1件取得する。SYSTEM_ADMINのみアクセス可能。
+      tags: [master-user]
+      parameters:
+        - $ref: '#/components/parameters/ResourceId'
+      responses:
+        '200':
+          description: ユーザー詳細
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserDetail'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: ユーザーが存在しない
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                userNotFound:
+                  summary: ユーザー未存在
+                  value:
+                    errorCode: USER_NOT_FOUND
+                    message: 指定されたユーザーが見つかりません
+
+    put:
+      operationId: updateUser
+      summary: ユーザー更新
+      description: |
+        指定されたIDのユーザー情報を更新する。ユーザーコードは変更不可。
+        自分自身のロール変更および無効化は禁止する。
+        SYSTEM_ADMINのみアクセス可能。
+      tags: [master-user]
+      parameters:
+        - $ref: '#/components/parameters/ResourceId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateUserRequest'
+      responses:
+        '200':
+          description: 更新成功
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserDetail'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: ユーザーが存在しない
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                userNotFound:
+                  summary: ユーザー未存在
+                  value:
+                    errorCode: USER_NOT_FOUND
+                    message: 指定されたユーザーが見つかりません
+        '409':
+          $ref: '#/components/responses/OptimisticLockConflict'
+        '422':
+          description: 業務ルール違反
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                cannotChangeSelfRole:
+                  summary: 自分自身のロール変更不可
+                  value:
+                    errorCode: CANNOT_CHANGE_SELF_ROLE
+                    message: 自分自身のロールを変更することはできません
+                cannotDeactivateSelf:
+                  summary: 自分自身の無効化不可
+                  value:
+                    errorCode: CANNOT_DEACTIVATE_SELF
+                    message: 自分自身を無効化することはできません
+
+  /api/v1/master/users/{id}/deactivate:
+    patch:
+      operationId: toggleUserActive
+      summary: ユーザー無効化/有効化
+      description: |
+        指定されたIDのユーザーの有効/無効フラグを切り替える。
+        自分自身の無効化は禁止する。SYSTEM_ADMINのみアクセス可能。
+      tags: [master-user]
+      parameters:
+        - $ref: '#/components/parameters/ResourceId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ToggleActiveRequest'
+      responses:
+        '200':
+          description: 更新成功
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserDetail'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: ユーザーが存在しない
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                userNotFound:
+                  summary: ユーザー未存在
+                  value:
+                    errorCode: USER_NOT_FOUND
+                    message: 指定されたユーザーが見つかりません
+        '409':
+          $ref: '#/components/responses/OptimisticLockConflict'
+        '422':
+          description: 業務ルール違反
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                cannotDeactivateSelf:
+                  summary: 自分自身の無効化不可
+                  value:
+                    errorCode: CANNOT_DEACTIVATE_SELF
+                    message: 自分自身を無効化することはできません
+
+  /api/v1/master/users/{id}/unlock:
+    patch:
+      operationId: unlockUser
+      summary: アカウントロック解除
+      description: |
+        ログイン連続失敗によりロックされたユーザーのアカウントロックを解除する。
+        locked・failed_login_count・locked_atを初期化する。
+        冪等性あり（ロック解除済みのユーザーへの解除要求も204を返す）。
+        SYSTEM_ADMINのみアクセス可能。
+      tags: [master-user]
+      parameters:
+        - $ref: '#/components/parameters/ResourceId'
+      responses:
+        '204':
+          description: ロック解除成功（レスポンスボディなし）
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: ユーザーが存在しない
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                userNotFound:
+                  summary: ユーザー未存在
+                  value:
+                    errorCode: USER_NOT_FOUND
+                    message: 指定されたユーザーが見つかりません
+
+  /api/v1/master/users/exists:
+    get:
+      operationId: checkUserCodeExists
+      summary: ユーザーコード存在確認
+      description: 指定されたユーザーコードがすでに登録されているか確認する。SYSTEM_ADMINのみアクセス可能。
+      tags: [master-user]
+      parameters:
+        - name: code
+          in: query
+          required: true
+          schema:
+            type: string
+          description: チェック対象のユーザーコード
+      responses:
+        '200':
+          description: 存在確認結果
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExistsResponse'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
 components:
   # ============================================================
   # Security Schemes
@@ -2898,6 +3204,126 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ProductDetail'
+        page:
+          type: integer
+        size:
+          type: integer
+        totalElements:
+          type: integer
+          format: int64
+        totalPages:
+          type: integer
+
+    # ----------------------------------------------------------
+    # Master User schemas
+    # ----------------------------------------------------------
+
+    UserStatus:
+      type: string
+      enum: [ACTIVE, INACTIVE, LOCKED]
+      description: ユーザーステータス（検索用）
+
+    CreateUserRequest:
+      type: object
+      required: [userCode, fullName, email, role, initialPassword]
+      properties:
+        userCode:
+          type: string
+          pattern: '^[a-zA-Z0-9_]{1,50}$'
+          description: ログインID（半角英数字とアンダースコアのみ、1〜50文字、登録後変更不可）
+        fullName:
+          type: string
+          minLength: 1
+          maxLength: 200
+          description: 氏名
+        email:
+          type: string
+          format: email
+          maxLength: 200
+          description: メールアドレス
+        role:
+          $ref: '#/components/schemas/UserRole'
+        initialPassword:
+          type: string
+          minLength: 8
+          maxLength: 128
+          description: 初期パスワード（平文で受け取りBCryptハッシュ化して保存）
+
+    UpdateUserRequest:
+      type: object
+      required: [fullName, email, role, isActive, version]
+      properties:
+        fullName:
+          type: string
+          minLength: 1
+          maxLength: 200
+          description: 氏名
+        email:
+          type: string
+          format: email
+          maxLength: 200
+          description: メールアドレス
+        role:
+          $ref: '#/components/schemas/UserRole'
+        isActive:
+          type: boolean
+          description: 有効フラグ
+        version:
+          type: integer
+          description: 楽観的ロックバージョン（取得時の値を送信）
+
+    UserDetail:
+      type: object
+      required: [id, userCode, fullName, email, role, isActive, locked, passwordChangeRequired, createdAt, updatedAt, version]
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: ユーザーID
+        userCode:
+          type: string
+          description: ログインID
+        fullName:
+          type: string
+          description: 氏名
+        email:
+          type: string
+          description: メールアドレス
+        role:
+          $ref: '#/components/schemas/UserRole'
+        isActive:
+          type: boolean
+          description: 有効フラグ
+        locked:
+          type: boolean
+          description: アカウントロックフラグ
+        lockedAt:
+          type: ['string', 'null']
+          format: date-time
+          description: ロック発生日時（未ロック時はnull）
+        passwordChangeRequired:
+          type: boolean
+          description: パスワード変更要求フラグ
+        createdAt:
+          type: string
+          format: date-time
+          description: 登録日時
+        updatedAt:
+          type: string
+          format: date-time
+          description: 最終更新日時
+        version:
+          type: integer
+          description: 楽観的ロックバージョン
+
+    UserPageResponse:
+      type: object
+      required: [content, page, size, totalElements, totalPages]
+      properties:
+        content:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserDetail'
         page:
           type: integer
         size:


### PR DESCRIPTION
## Summary
- ユーザーマスタ（MST-USR）の全7エンドポイントをOpenAPI定義に追加
- ユーザー一覧取得、登録、取得、更新、無効化/有効化、アカウントロック解除、コード存在確認
- UserDetail, CreateUserRequest, UpdateUserRequest, UserStatus, UserPageResponse スキーマを追加

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)