### PR TITLE
docs: 在庫訂正のreason最大文字数を200に統一

### DIFF
--- a/docs/functional-design/API-07-inventory.md
+++ b/docs/functional-design/API-07-inventory.md
@@ -703,7 +703,7 @@ flowchart TD
 | # | ルール | エラーコード |
 |---|--------|------------|
 | 1 | `newQty` は 0 以上の整数であること | `VALIDATION_ERROR` |
-| 2 | `reason` は 1 文字以上 500 文字以下であること | `VALIDATION_ERROR` |
+| 2 | `reason` は 1 文字以上 200 文字以下であること | `VALIDATION_ERROR` |
 | 3 | 実行者のロールが `SYSTEM_ADMIN` または `WAREHOUSE_MANAGER` であること | `FORBIDDEN` |
 | 4 | 対象ロケーションが棚卸ロック中でないこと | `INVENTORY_STOCKTAKE_IN_PROGRESS` |
 | 5 | 対象在庫レコード（5軸一致）が存在すること | `INVENTORY_NOT_FOUND` |


### PR DESCRIPTION
## Summary
- API-07-inventory.md のビジネスルール表で `reason` の最大文字数が500文字と記載されていたが、同一ファイル内のリクエスト仕様・補足事項およびOpenAPI定義では200文字で統一されていたため、200文字に修正

## Test plan
- [x] 同一ファイル内の3箇所（リクエスト仕様・ビジネスルール・補足事項）が全て200文字で統一
- [x] OpenAPI定義の `maxLength: 200` と一致

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)