### PR TITLE
設計書: フィルター実行順序の明記・RequestLoggingFilterコード例更新

### DIFF
--- a/docs/architecture-design/04-backend-architecture.md
+++ b/docs/architecture-design/04-backend-architecture.md
@@ -1556,9 +1556,12 @@ public class TraceIdFilter extends OncePerRequestFilter {
 
 ### 9.3 リクエストロギング
 
+> フィルター実行順序の詳細は [08-common-infrastructure.md §4](08-common-infrastructure.md) のサーブレットフィルター実行順序を参照。
+
 ```java
 @Component
 @Slf4j
+@Order(Ordered.HIGHEST_PRECEDENCE + 1)  // TraceIdFilter(HIGHEST_PRECEDENCE) の直後
 public class RequestLoggingFilter extends OncePerRequestFilter {
 
     @Override
@@ -1566,16 +1569,30 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
                                      HttpServletResponse response,
                                      FilterChain filterChain)
             throws ServletException, IOException {
-        long startTime = System.currentTimeMillis();
+        long startTime = System.nanoTime();
+        Throwable thrown = null;
 
-        filterChain.doFilter(request, response);
-
-        long duration = System.currentTimeMillis() - startTime;
-        log.info("API request completed: method={}, path={}, status={}, duration={}ms",
-                request.getMethod(),
-                request.getRequestURI(),
-                response.getStatus(),
-                duration);
+        try {
+            filterChain.doFilter(request, response);
+        } catch (Exception ex) {
+            thrown = ex;
+            throw ex;
+        } finally {
+            long durationMs = (System.nanoTime() - startTime) / 1_000_000;
+            if (thrown != null) {
+                log.warn("API request failed: method={}, path={}, duration={}ms, error={}",
+                        request.getMethod(),
+                        request.getRequestURI(),
+                        durationMs,
+                        thrown.getMessage());
+            } else {
+                log.info("API request completed: method={}, path={}, status={}, duration={}ms",
+                        request.getMethod(),
+                        request.getRequestURI(),
+                        response.getStatus(),
+                        durationMs);
+            }
+        }
     }
 }
 ```

--- a/docs/architecture-design/08-common-infrastructure.md
+++ b/docs/architecture-design/08-common-infrastructure.md
@@ -873,6 +873,16 @@ export function useWarehouseForm(mode: 'create' | 'edit') {
 
 > ログ収集フロー・標準フォーマット・PII マスキングは [architecture-blueprint/08-common-infrastructure.md](../architecture-blueprint/08-common-infrastructure.md) を参照。
 
+#### サーブレットフィルター実行順序
+
+| 順序 | フィルター | @Order | 役割 |
+|------|-----------|--------|------|
+| 1 | `TraceIdFilter` | `Ordered.HIGHEST_PRECEDENCE` | traceId 生成・MDC 設定 |
+| 2 | `RequestLoggingFilter` | `Ordered.HIGHEST_PRECEDENCE + 1` | リクエスト計時・アクセスログ |
+| 3 | Spring Security FilterChain | デフォルト | 認証・認可（JWT検証、userId MDC設定） |
+
+> **設計意図**: TraceIdFilter を最優先で実行し、後続の全フィルター・ログに traceId が付与されることを保証する。RequestLoggingFilter はその直後に配置し、セキュリティフィルターを含むリクエスト全体の処理時間を計測する。
+
 ### 4.1 バックエンド — 相関ID（TraceId）管理
 
 リクエストごとにUUID v4 を生成し、MDC（Mapped Diagnostic Context）に設定する。全ログに自動付与される。


### PR DESCRIPTION
## Summary
- `08-common-infrastructure.md` §4 にサーブレットフィルター実行順序テーブルを追加（TraceIdFilter → RequestLoggingFilter → Spring Security FilterChain）
- `04-backend-architecture.md` §9.3 の RequestLoggingFilter コード例を実装と一致するよう更新（`@Order`, try/catch/finally, `System.nanoTime()`）

## Test plan
- [x] ドキュメント変更のみ。実装コード（PR #45）と設計書の整合性を確認済み

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)