### PR TITLE
WarehouseService に楽観ロック事前チェックを追加

### DIFF
--- a/backend/src/main/java/com/wms/master/service/WarehouseService.java
+++ b/backend/src/main/java/com/wms/master/service/WarehouseService.java
@@ -67,6 +67,11 @@ public class WarehouseService {
     public Warehouse update(Long id, String warehouseName, String warehouseNameKana,
                             String address, Integer version) {
         Warehouse warehouse = findById(id);
+        if (!warehouse.getVersion().equals(version)) {
+            throw new OptimisticLockConflictException(
+                    "OPTIMISTIC_LOCK_CONFLICT",
+                    "他のユーザーによる更新が先行しました (id=" + id + ")");
+        }
         warehouse.setWarehouseName(warehouseName);
         warehouse.setWarehouseNameKana(warehouseNameKana);
         warehouse.setAddress(address);
@@ -85,7 +90,16 @@ public class WarehouseService {
     @Transactional
     public Warehouse toggleActive(Long id, boolean isActive, Integer version) {
         Warehouse warehouse = findById(id);
+        if (!warehouse.getVersion().equals(version)) {
+            throw new OptimisticLockConflictException(
+                    "OPTIMISTIC_LOCK_CONFLICT",
+                    "他のユーザーによる更新が先行しました (id=" + id + ")");
+        }
         // TODO: 在庫テーブル実装後に在庫存在チェックを追加（無効化時）
+        if (warehouse.getIsActive().equals(isActive)) {
+            log.info("Warehouse toggleActive no-op: id={}, isActive={}", id, isActive);
+            return warehouse;
+        }
         if (isActive) {
             warehouse.activate();
         } else {

--- a/backend/src/test/java/com/wms/master/service/WarehouseServiceTest.java
+++ b/backend/src/test/java/com/wms/master/service/WarehouseServiceTest.java
@@ -20,12 +20,14 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -98,6 +100,24 @@ class WarehouseServiceTest {
     }
 
     @Nested
+    @DisplayName("findByIds")
+    class FindByIds {
+        @Test
+        @DisplayName("複数IDでMapを返す")
+        void findByIds_returnsMap() {
+            Warehouse w1 = createWarehouse(1L, "WARA", "東京DC");
+            Warehouse w2 = createWarehouse(2L, "WARB", "大阪DC");
+            when(warehouseRepository.findAllById(List.of(1L, 2L))).thenReturn(List.of(w1, w2));
+
+            Map<Long, Warehouse> result = warehouseService.findByIds(List.of(1L, 2L));
+
+            assertThat(result).hasSize(2);
+            assertThat(result.get(1L).getWarehouseCode()).isEqualTo("WARA");
+            assertThat(result.get(2L).getWarehouseCode()).isEqualTo("WARB");
+        }
+    }
+
+    @Nested
     @DisplayName("create")
     class Create {
         @Test
@@ -164,6 +184,16 @@ class WarehouseServiceTest {
         }
 
         @Test
+        @DisplayName("バージョン不一致で事前チェックによるOptimisticLockConflictExceptionをスロー")
+        void update_versionMismatch_throwsException() {
+            Warehouse existing = createWarehouse(1L, "WARA", "東京DC");
+            when(warehouseRepository.findById(1L)).thenReturn(Optional.of(existing));
+
+            assertThatThrownBy(() -> warehouseService.update(1L, "名前", null, null, 99))
+                    .isInstanceOf(OptimisticLockConflictException.class);
+        }
+
+        @Test
         @DisplayName("楽観的ロック競合でOptimisticLockConflictExceptionをスロー")
         void update_optimisticLockConflict_throwsException() {
             Warehouse existing = createWarehouse(1L, "WARA", "東京DC");
@@ -202,6 +232,28 @@ class WarehouseServiceTest {
             Warehouse result = warehouseService.toggleActive(1L, true, 0);
 
             assertThat(result.getIsActive()).isTrue();
+        }
+
+        @Test
+        @DisplayName("既に同じ状態の場合はUPDATEなし（冪等性）")
+        void toggleActive_alreadySameState_noUpdate() {
+            Warehouse existing = createWarehouse(1L, "WARA", "東京DC");
+            when(warehouseRepository.findById(1L)).thenReturn(Optional.of(existing));
+
+            Warehouse result = warehouseService.toggleActive(1L, true, 0);
+
+            assertThat(result.getIsActive()).isTrue();
+            verify(warehouseRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("バージョン不一致で事前チェックによるOptimisticLockConflictExceptionをスロー")
+        void toggleActive_versionMismatch_throwsException() {
+            Warehouse existing = createWarehouse(1L, "WARA", "東京DC");
+            when(warehouseRepository.findById(1L)).thenReturn(Optional.of(existing));
+
+            assertThatThrownBy(() -> warehouseService.toggleActive(1L, false, 99))
+                    .isInstanceOf(OptimisticLockConflictException.class);
         }
 
         @Test


### PR DESCRIPTION
## Summary
- WarehouseService.update() に version 事前チェックを追加
- WarehouseService.toggleActive() に version 事前チェック＋冪等性チェックを追加
- findByIds のテストを追加し C0/C1 100% 達成

Building/Area/Location の各Service で実装済みのパターンを WarehouseService にも適用し、一貫性を確保。

## Test coverage
| 指標 | 値 |
|------|-----|
| C0（ステートメント） | 100% |
| C1（ブランチ） | 100% |

## Test plan
- [x] update: バージョン不一致で事前チェックによる OptimisticLockConflictException
- [x] update: DB楽観ロック競合による OptimisticLockConflictException（既存テスト）
- [x] toggleActive: バージョン不一致で事前チェックによる OptimisticLockConflictException
- [x] toggleActive: 既に同じ状態の場合 no-op（冪等性）
- [x] toggleActive: DB楽観ロック競合による OptimisticLockConflictException（既存テスト）
- [x] findByIds: 複数IDでMapを返す

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)