### PR TITLE
feat: AbortController で一覧取得の Race Condition を解消 (#102)

### DIFF
--- a/frontend/src/composables/master/useWarehouseList.ts
+++ b/frontend/src/composables/master/useWarehouseList.ts
@@ -1,4 +1,4 @@
-import { ref, reactive } from 'vue'
+import { ref, reactive, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import axios from 'axios'
@@ -43,6 +43,12 @@ export function useWarehouseList() {
   // 新しいリクエストが来たら前のリクエストをキャンセルし、
   // 古いレスポンスで画面が上書きされる Race Condition を防ぐ
   let abortController: AbortController | null = null
+
+  // コンポーネントのアンマウント時に進行中のリクエストをキャンセルし、
+  // アンマウント後のステート更新（メモリリーク）を防ぐ
+  onUnmounted(() => {
+    abortController?.abort()
+  })
 
   // --- API呼び出し ---
   async function fetchList() {


### PR DESCRIPTION
## 概要

Issue #102 の対応。一覧取得 `fetchList()` に `AbortController` を導入し、連続操作時に古いレスポンスで画面が上書きされる Race Condition を解消する。

## 変更内容

`useWarehouseList.ts` のみ変更。

### 実装方針

```
新リクエスト発行時 → abortController.abort() で前のリクエストをキャンセル
                   → 新しい AbortController を生成して signal を axios に渡す
キャンセル時       → axios.isCancel() で検出し、エラートーストを出さず早期 return
loading 管理       → signal.aborted チェックで、キャンセル済みリクエストは
                     loading = false をスキップ（後続リクエストに委ねる）
```

### loading の正確な管理

```
[操作A] loading=true → [操作B発行] A をキャンセル、loading=true（継続） → Aのfinally: signal.aborted=true のためスキップ → Bが完了 → loading=false
```

キャンセルなしの場合は従来通り finally で `loading = false`。

## Test coverage
| 指標 | 値 |
|------|-----|
| C0 | N/A（フロントエンド） |
| C1 | N/A（フロントエンド） |

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)