### PR TITLE
OpenApiConfig のセキュリティスキームを Bearer → Cookie認証に変更

### DIFF
--- a/backend/src/main/java/com/wms/shared/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/wms/shared/config/OpenApiConfig.java
@@ -13,7 +13,7 @@ import org.springframework.context.annotation.Profile;
 @Profile("!prd")
 public class OpenApiConfig {
 
-    public static final String SECURITY_SCHEME_NAME = "bearerAuth";
+    public static final String SECURITY_SCHEME_NAME = "cookieAuth";
 
     @Bean
     public OpenAPI wmsOpenAPI() {
@@ -27,9 +27,11 @@ public class OpenApiConfig {
                 .components(new Components()
                         .addSecuritySchemes(SECURITY_SCHEME_NAME,
                                 new SecurityScheme()
-                                        .name(SECURITY_SCHEME_NAME)
-                                        .type(SecurityScheme.Type.HTTP)
-                                        .scheme("bearer")
-                                        .bearerFormat("JWT")));
+                                        .name("access_token")
+                                        .type(SecurityScheme.Type.APIKEY)
+                                        .in(SecurityScheme.In.COOKIE)
+                                        .description("JWTアクセストークン（httpOnly Cookie）。"
+                                                + "Swagger UIでは /api/v1/auth/login でログイン後、"
+                                                + "ブラウザにCookieが設定されるため自動的に認証されます。")));
     }
 }

--- a/backend/src/test/java/com/wms/shared/config/OpenApiConfigTest.java
+++ b/backend/src/test/java/com/wms/shared/config/OpenApiConfigTest.java
@@ -28,14 +28,14 @@ class OpenApiConfigTest {
     }
 
     @Test
-    @DisplayName("Bearer JWT セキュリティスキームが定義される")
+    @DisplayName("Cookie認証セキュリティスキームが定義される")
     void wmsOpenAPI_default_hasSecurityScheme() {
         assertThat(openAPI.getComponents().getSecuritySchemes())
-                .containsKey("bearerAuth");
-        var scheme = openAPI.getComponents().getSecuritySchemes().get("bearerAuth");
-        assertThat(scheme.getType().toString()).isEqualToIgnoringCase("HTTP");
-        assertThat(scheme.getScheme()).isEqualTo("bearer");
-        assertThat(scheme.getBearerFormat()).isEqualTo("JWT");
+                .containsKey("cookieAuth");
+        var scheme = openAPI.getComponents().getSecuritySchemes().get("cookieAuth");
+        assertThat(scheme.getType().toString()).isEqualToIgnoringCase("APIKEY");
+        assertThat(scheme.getIn().toString()).isEqualToIgnoringCase("COOKIE");
+        assertThat(scheme.getName()).isEqualTo("access_token");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- OpenApiConfig のセキュリティスキームを `bearerAuth` (HTTP Bearer) → `cookieAuth` (apiKey in cookie) に変更
- OpenAPI spec (`wms-api.yaml`) の `cookieAuth` 定義と整合
- Swagger UI でのテスト方法を description に記載（ログイン後 Cookie が自動設定される旨）

## Test coverage
| 指標 | 値 |
|------|-----|
| C0（ステートメント） | 100% |
| C1（ブランチ） | 100% |

## Test plan
- [x] OpenApiConfigTest: cookieAuth スキームの type=APIKEY, in=COOKIE, name=access_token を検証
- [x] グローバルセキュリティ要件なしの検証（既存テスト）

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)