### PR TITLE
入荷実績照会フロントエンド実装（INB-006）

### DIFF
--- a/frontend/src/composables/inbound/useInboundResults.ts
+++ b/frontend/src/composables/inbound/useInboundResults.ts
@@ -1,0 +1,148 @@
+import { ref, reactive, onUnmounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { ElMessage } from 'element-plus'
+import axios from 'axios'
+import apiClient from '@/api/client'
+import { toApiError } from '@/utils/apiError'
+import { useWarehouseStore } from '@/stores/warehouse'
+import type { InboundResultItem } from '@/api/generated/models/inbound-result-item'
+import type { InboundResultPageResponse } from '@/api/generated/models/inbound-result-page-response'
+
+function formatDate(d: Date): string {
+  return d.toISOString().slice(0, 10)
+}
+
+export function useInboundResults() {
+  const { t } = useI18n()
+  const warehouseStore = useWarehouseStore()
+
+  // SCR-07 INB006: デフォルト日付 = 月初〜当日
+  const today = new Date()
+  const monthStart = new Date(today.getFullYear(), today.getMonth(), 1)
+
+  const items = ref<InboundResultItem[]>([])
+  const loading = ref(false)
+  const total = ref(0)
+  const page = ref(1)
+  const pageSize = ref(20)
+
+  const searchForm = reactive({
+    storedDateFrom: formatDate(monthStart) as string | null,
+    storedDateTo: formatDate(today) as string | null,
+    partnerId: null as number | null,
+    slipNumber: '',
+    productCode: '',
+  })
+
+  const partnerOptions = ref<{ id: number; partnerName: string }[]>([])
+
+  async function fetchPartnerOptions() {
+    try {
+      const [resSupplier, resBoth] = await Promise.all([
+        apiClient.get('/master/partners', {
+          params: { page: 0, size: 1000, isActive: true, partnerType: 'SUPPLIER', sort: 'partnerName,asc' },
+        }),
+        apiClient.get('/master/partners', {
+          params: { page: 0, size: 1000, isActive: true, partnerType: 'BOTH', sort: 'partnerName,asc' },
+        }),
+      ])
+      const toOption = (p: { id: number; partnerName: string }) => ({ id: p.id, partnerName: p.partnerName })
+      partnerOptions.value = [
+        ...resSupplier.data.content.map(toOption),
+        ...resBoth.data.content.map(toOption),
+      ]
+    } catch {
+      // エラーは無視
+    }
+  }
+
+  let abortController: AbortController | null = null
+  onUnmounted(() => {
+    abortController?.abort()
+  })
+
+  async function fetchList() {
+    abortController?.abort()
+    abortController = new AbortController()
+    const signal = abortController.signal
+
+    loading.value = true
+    try {
+      const params: Record<string, unknown> = {
+        warehouseId: warehouseStore.currentWarehouseId,
+        page: page.value - 1,
+        size: pageSize.value,
+      }
+      if (searchForm.storedDateFrom) params.storedDateFrom = searchForm.storedDateFrom
+      if (searchForm.storedDateTo) params.storedDateTo = searchForm.storedDateTo
+      if (searchForm.partnerId) params.partnerId = searchForm.partnerId
+      if (searchForm.slipNumber) params.slipNumber = searchForm.slipNumber
+      if (searchForm.productCode) params.productCode = searchForm.productCode
+
+      const res = await apiClient.get<InboundResultPageResponse>('/inbound/results', {
+        params,
+        signal,
+      })
+      items.value = res.data.content ?? []
+      total.value = res.data.totalElements ?? 0
+    } catch (err: unknown) {
+      if (axios.isCancel(err)) return
+      items.value = []
+      total.value = 0
+      const error = toApiError(err)
+      if (!error.response) {
+        ElMessage.error(t('error.network'))
+      } else {
+        ElMessage.error(t('inbound.results.fetchError'))
+      }
+    } finally {
+      if (!signal.aborted) {
+        loading.value = false
+      }
+    }
+  }
+
+  function handleSearch() {
+    page.value = 1
+    fetchList()
+  }
+
+  function handleReset() {
+    const now = new Date()
+    const ms = new Date(now.getFullYear(), now.getMonth(), 1)
+    searchForm.storedDateFrom = formatDate(ms)
+    searchForm.storedDateTo = formatDate(now)
+    searchForm.partnerId = null
+    searchForm.slipNumber = ''
+    searchForm.productCode = ''
+    page.value = 1
+    fetchList()
+  }
+
+  function handlePageChange(p: number) {
+    page.value = p
+    fetchList()
+  }
+
+  function handleSizeChange(s: number) {
+    pageSize.value = s
+    page.value = 1
+    fetchList()
+  }
+
+  return {
+    items,
+    loading,
+    total,
+    page,
+    pageSize,
+    searchForm,
+    partnerOptions,
+    fetchList,
+    fetchPartnerOptions,
+    handleSearch,
+    handleReset,
+    handlePageChange,
+    handleSizeChange,
+  }
+}

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -576,6 +576,13 @@ export default {
       diffWarning: '{count} line(s) have differences. Proceed?',
       noDiffConfirm: 'All lines match planned quantities. Proceed?',
     },
+    results: {
+      title: 'Inbound Results',
+      storedDateFrom: 'Stored Date (From)',
+      storedDateTo: 'Stored Date (To)',
+      storedDate: 'Stored Date',
+      fetchError: 'Failed to fetch inbound results',
+    },
     store: {
       title: 'Store Lines',
       location: 'Store Location',

--- a/frontend/src/i18n/locales/ja.ts
+++ b/frontend/src/i18n/locales/ja.ts
@@ -579,6 +579,13 @@ export default {
       diffWarning: '{count}件の明細に差異があります。このまま確定しますか？',
       noDiffConfirm: '全明細が予定数通りです。このまま確定しますか？',
     },
+    results: {
+      title: '入荷実績照会',
+      storedDateFrom: '入庫日（From）',
+      storedDateTo: '入庫日（To）',
+      storedDate: '入庫日',
+      fetchError: '入荷実績の取得に失敗しました',
+    },
     store: {
       title: '入庫明細',
       location: '入庫先ロケーション',

--- a/frontend/src/pages/inbound/InboundResultsPage.vue
+++ b/frontend/src/pages/inbound/InboundResultsPage.vue
@@ -1,20 +1,162 @@
 <template>
   <div class="wms-page">
-    <el-card>
-      <el-result icon="info" title="入荷実績照会" sub-title="この画面は後続Issueで実装予定です">
-        <template #extra>
-          <el-button @click="router.push({ name: 'inbound-slip-list' })">一覧に戻る</el-button>
+    <!-- 絞り込みフォーム -->
+    <el-card class="search-card">
+      <el-form :model="searchForm" inline @submit.prevent="handleSearch">
+        <el-form-item :label="t('inbound.results.storedDateFrom')">
+          <el-date-picker
+            v-model="searchForm.storedDateFrom"
+            type="date"
+            value-format="YYYY-MM-DD"
+            style="width: 160px"
+            clearable
+          />
+        </el-form-item>
+        <el-form-item :label="t('inbound.results.storedDateTo')">
+          <el-date-picker
+            v-model="searchForm.storedDateTo"
+            type="date"
+            value-format="YYYY-MM-DD"
+            style="width: 160px"
+            clearable
+          />
+        </el-form-item>
+        <el-form-item :label="t('inbound.slip.partner')">
+          <el-select
+            v-model="searchForm.partnerId"
+            style="width: 200px"
+            clearable
+            filterable
+            :placeholder="t('inbound.slip.partnerAll')"
+          >
+            <el-option
+              v-for="p in partnerOptions"
+              :key="p.id"
+              :label="p.partnerName"
+              :value="p.id"
+            />
+          </el-select>
+        </el-form-item>
+        <el-form-item :label="t('inbound.slip.slipNumber')">
+          <el-input
+            v-model="searchForm.slipNumber"
+            :placeholder="t('inbound.slip.slipNumber')"
+            clearable
+            style="width: 180px"
+          />
+        </el-form-item>
+        <el-form-item :label="t('inbound.slip.productCode')">
+          <el-input
+            v-model="searchForm.productCode"
+            :placeholder="t('inbound.slip.productCode')"
+            clearable
+            style="width: 140px"
+          />
+        </el-form-item>
+        <el-form-item>
+          <el-button type="primary" native-type="submit" :icon="Search">
+            {{ t('common.search') }}
+          </el-button>
+          <el-button :icon="Refresh" @click="handleReset">
+            {{ t('common.reset') }}
+          </el-button>
+        </el-form-item>
+      </el-form>
+    </el-card>
+
+    <!-- 実績テーブル -->
+    <el-card class="table-card">
+      <template #header>
+        <span>{{ t('inbound.results.title') }}</span>
+      </template>
+
+      <el-table v-loading="loading" :data="items" stripe border style="width: 100%">
+        <el-table-column prop="slipNumber" :label="t('inbound.slip.slipNumber')" width="180">
+          <template #default="{ row }">
+            <el-link
+              type="primary"
+              @click="router.push({ name: 'inbound-slip-detail', params: { id: row.slipId } })"
+            >
+              {{ row.slipNumber }}
+            </el-link>
+          </template>
+        </el-table-column>
+        <el-table-column prop="storedAt" :label="t('inbound.results.storedDate')" width="160">
+          <template #default="{ row }">
+            {{ formatDateTime(row.storedAt) }}
+          </template>
+        </el-table-column>
+        <el-table-column prop="partnerName" :label="t('inbound.slip.partner')" width="140" />
+        <el-table-column prop="productCode" :label="t('inbound.slip.productCode')" width="120" />
+        <el-table-column prop="productName" :label="t('inbound.slip.productName')" min-width="140" />
+        <el-table-column prop="plannedQty" :label="t('inbound.slip.plannedQty')" width="90" align="right" />
+        <el-table-column prop="inspectedQty" :label="t('inbound.inspect.inspectedQty')" width="90" align="right" />
+        <el-table-column :label="t('inbound.inspect.diffQty')" width="80" align="right">
+          <template #default="{ row }">
+            <span :class="{ 'text-danger': row.diffQty !== 0 }">
+              {{ row.diffQty }}
+            </span>
+          </template>
+        </el-table-column>
+        <template #empty>
+          <el-empty :description="t('common.noData')" />
         </template>
-      </el-result>
+      </el-table>
+
+      <div class="pagination-wrapper">
+        <el-pagination
+          v-model:current-page="page"
+          v-model:page-size="pageSize"
+          :total="total"
+          :page-sizes="[20, 50, 100]"
+          layout="total, sizes, prev, pager, next"
+          background
+          @current-change="handlePageChange"
+          @size-change="handleSizeChange"
+        />
+      </div>
     </el-card>
   </div>
 </template>
 
 <script setup lang="ts">
+import { onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
+import { Search, Refresh } from '@element-plus/icons-vue'
+import { useInboundResults } from '@/composables/inbound/useInboundResults'
+import { formatDateTime } from '@/utils/inboundFormatters'
+
+const { t } = useI18n()
 const router = useRouter()
+
+const {
+  items, loading, total, page, pageSize, searchForm, partnerOptions,
+  fetchList, fetchPartnerOptions, handleSearch, handleReset, handlePageChange, handleSizeChange,
+} = useInboundResults()
+
+onMounted(() => {
+  fetchPartnerOptions()
+  fetchList()
+})
 </script>
 
 <style scoped lang="scss">
-.wms-page { padding: 20px; }
+.wms-page {
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.pagination-wrapper {
+  margin-top: 16px;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.text-danger {
+  color: var(--el-color-danger);
+  font-weight: bold;
+}
 </style>


### PR DESCRIPTION
Closes #185

## Summary
- 入荷実績照会画面（INB-006）のフロントエンド実装
- 絞り込みフォーム（入庫日From/To・仕入先・伝票番号・商品コード）
- 実績テーブル（伝票番号→詳細リンク・差異数赤字表示）
- ページネーション

## Test coverage
フロントエンドのため、JaCoCoカバレッジ計測対象外

## Test plan
- [x] vue-tsc 型チェック通過
- [x] 絞り込み: 日付範囲・仕入先・伝票番号・商品コード
- [x] テーブル: 差異数0以外は赤字表示
- [x] 伝票番号クリック→詳細画面遷移

🤖 Generated with [Claude Code](https://claude.com/claude-code)