### PR TITLE
feat: ドキュメント関連マップを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,15 @@
 3. **レビューで矛盾を見つけた時**: SSOT側を正とし、複製側を参照リンクに置き換える
 4. **例外**: 画面設計書のイベント一覧にはAPIエンドポイントパス（`POST /api/v1/xxx`）を記載してよい（開発時の利便性のため）。ただしリクエスト/レスポンスの詳細は複製しない
 
+## ドキュメント関連マップ
+
+実装・レビュー・設計変更の際は **[docs/document-map.yaml](docs/document-map.yaml)** で対象モジュールの関連ドキュメントを確認すること。
+
+- **SSOT**: `docs/document-map.yaml`（YAMLが定義場所）
+- **閲覧用**: `docs/document-map.md`（自動生成。`node docs/scripts/build-docs.js --generate-map` で再生成）
+- モジュールごとに要件定義・API設計・画面設計・帳票・テスト仕様・データモデル・アーキテクチャの関連が定義されている
+- 新しいドキュメントを追加した場合は `document-map.yaml` も更新すること
+
 ## アーキテクチャルール（実装時の必読事項）
 
 実装作業を開始する前に必ず **[docs/ARCHITECTURE-RULES.md](docs/ARCHITECTURE-RULES.md)** を読み込むこと。

--- a/docs/document-map.md
+++ b/docs/document-map.md
@@ -1,0 +1,315 @@
+# ドキュメント関連マップ (Document Relationship Map)
+
+> **このファイルは `docs/document-map.yaml` から自動生成されています。直接編集しないでください。**
+> 
+> 再生成: `node docs/scripts/build-docs.js --generate-map`
+
+## モジュール × ドキュメント種別 マトリクス
+
+| モジュール | 要件定義 | API設計 | 画面設計 | 帳票 | バッチ | I/F | データモデル | テスト | アーキテクチャ |
+|-----------|---------|---------|---------|------|--------|-----|-------------|--------|--------------|
+| **認証・認可** | 00-authentication | API-01-auth | SCR-01-auth | — | — | — | 02-master-tables | TST-AUTH-login-password | 07-auth-architecture, 10-security-architecture |
+| **マスタ管理** | 01-master-management | API-02-master-facility, API-03-master-partner, API-04-master-product, API-05-master-user | SCR-02-master-facility, SCR-03-master-partner, SCR-04-master-warehouse, SCR-05-master-product, SCR-06-master-user | — | — | — | 02-master-tables | TST-MST-master-management | — |
+| **システムパラメータ** | 01a-system-parameters | API-11-system-parameters | SCR-12-system-parameters | — | — | — | 02-master-tables | TST-SYS-parameters | — |
+| **入荷管理** | 02-inbound-management | API-06-inbound | SCR-07-inbound | RPT-01-inbound-inspection, RPT-03-inbound-plan, RPT-04-inbound-result, RPT-05-unreceived-realtime, RPT-06-unreceived-confirmed | — | IF-01-inbound-plan | 03-transaction-tables | TST-INB-inbound | — |
+| **在庫管理** | 03-inventory-management | API-07-inventory | SCR-08-inventory-ops, SCR-09-inventory-stocktake | RPT-07-inventory, RPT-08-inventory-transition, RPT-09-inventory-correction, RPT-10-stocktake-list, RPT-11-stocktake-result | — | — | 03-transaction-tables | TST-INV-inventory | — |
+| **出荷管理** | 04-outbound-management | API-08-outbound | SCR-10-outbound | RPT-12-picking-instruction, RPT-13-shipping-inspection, RPT-14-delivery-list, RPT-15-unshipped-realtime, RPT-16-unshipped-confirmed | — | IF-02-order | 03-transaction-tables | TST-OUT-outbound | — |
+| **在庫引当** | 04a-allocation | API-12-allocation | SCR-13-allocation | — | — | — | 03-transaction-tables | TST-ALL-allocation | — |
+| **返品管理** | 08-returns | API-13-returns | SCR-14-returns | RPT-18-returns | — | — | 03-transaction-tables | TST-RTN-returns | — |
+| **バッチ処理** | 06-batch-processing | API-09-batch | SCR-11-batch | — | BAT-01-daily-close | — | 04-batch-tables | TST-BAT-batch | — |
+| **レポート共通** | 05-reports | API-10-report | — | RPT-17-daily-summary | — | — | — | TST-RPT-reports | — |
+| **外部連携I/F** | 07-interface | — | SCR-15-interface | — | — | — | — | TST-IF-interface | 09-interface-architecture |
+
+## モジュール別 詳細
+
+### 認証・認可 (Authentication & Authorization)
+
+**📝 要件定義:**
+- [00-authentication](functional-requirements/00-authentication.md)
+
+**🔌 API設計:**
+- [API-01-auth](functional-design/API-01-auth.md)
+
+**🖥️ 画面設計:**
+- [SCR-01-auth](functional-design/SCR-01-auth.md)
+
+**🗄️ データモデル:**
+- [02-master-tables](data-model/02-master-tables.md)
+
+**🧪 テスト仕様:**
+- [TST-AUTH-login-password](test-specifications/TST-AUTH-login-password.md)
+
+**🏗️ アーキテクチャ:**
+- [07-auth-architecture](architecture-blueprint/07-auth-architecture.md)
+- [10-security-architecture](architecture-blueprint/10-security-architecture.md)
+
+### マスタ管理 (Master Management)
+
+**📝 要件定義:**
+- [01-master-management](functional-requirements/01-master-management.md)
+
+**🔌 API設計:**
+- [API-02-master-facility](functional-design/API-02-master-facility.md)
+- [API-03-master-partner](functional-design/API-03-master-partner.md)
+- [API-04-master-product](functional-design/API-04-master-product.md)
+- [API-05-master-user](functional-design/API-05-master-user.md)
+
+**🖥️ 画面設計:**
+- [SCR-02-master-facility](functional-design/SCR-02-master-facility.md)
+- [SCR-03-master-partner](functional-design/SCR-03-master-partner.md)
+- [SCR-04-master-warehouse](functional-design/SCR-04-master-warehouse.md)
+- [SCR-05-master-product](functional-design/SCR-05-master-product.md)
+- [SCR-06-master-user](functional-design/SCR-06-master-user.md)
+
+**🗄️ データモデル:**
+- [02-master-tables](data-model/02-master-tables.md)
+
+**🧪 テスト仕様:**
+- [TST-MST-master-management](test-specifications/TST-MST-master-management.md)
+
+### システムパラメータ (System Parameters)
+
+**📝 要件定義:**
+- [01a-system-parameters](functional-requirements/01a-system-parameters.md)
+
+**🔌 API設計:**
+- [API-11-system-parameters](functional-design/API-11-system-parameters.md)
+
+**🖥️ 画面設計:**
+- [SCR-12-system-parameters](functional-design/SCR-12-system-parameters.md)
+
+**🗄️ データモデル:**
+- [02-master-tables](data-model/02-master-tables.md)
+
+**🧪 テスト仕様:**
+- [TST-SYS-parameters](test-specifications/TST-SYS-parameters.md)
+
+### 入荷管理 (Inbound Management)
+
+**📝 要件定義:**
+- [02-inbound-management](functional-requirements/02-inbound-management.md)
+
+**🔌 API設計:**
+- [API-06-inbound](functional-design/API-06-inbound.md)
+
+**🖥️ 画面設計:**
+- [SCR-07-inbound](functional-design/SCR-07-inbound.md)
+
+**📊 帳票設計:**
+- [RPT-01-inbound-inspection](functional-design/RPT-01-inbound-inspection.md)
+- [RPT-03-inbound-plan](functional-design/RPT-03-inbound-plan.md)
+- [RPT-04-inbound-result](functional-design/RPT-04-inbound-result.md)
+- [RPT-05-unreceived-realtime](functional-design/RPT-05-unreceived-realtime.md)
+- [RPT-06-unreceived-confirmed](functional-design/RPT-06-unreceived-confirmed.md)
+
+**🔗 I/F設計:**
+- [IF-01-inbound-plan](functional-design/IF-01-inbound-plan.md)
+
+**🗄️ データモデル:**
+- [03-transaction-tables](data-model/03-transaction-tables.md)
+
+**🧪 テスト仕様:**
+- [TST-INB-inbound](test-specifications/TST-INB-inbound.md)
+
+### 在庫管理 (Inventory Management)
+
+**📝 要件定義:**
+- [03-inventory-management](functional-requirements/03-inventory-management.md)
+
+**🔌 API設計:**
+- [API-07-inventory](functional-design/API-07-inventory.md)
+
+**🖥️ 画面設計:**
+- [SCR-08-inventory-ops](functional-design/SCR-08-inventory-ops.md)
+- [SCR-09-inventory-stocktake](functional-design/SCR-09-inventory-stocktake.md)
+
+**📊 帳票設計:**
+- [RPT-07-inventory](functional-design/RPT-07-inventory.md)
+- [RPT-08-inventory-transition](functional-design/RPT-08-inventory-transition.md)
+- [RPT-09-inventory-correction](functional-design/RPT-09-inventory-correction.md)
+- [RPT-10-stocktake-list](functional-design/RPT-10-stocktake-list.md)
+- [RPT-11-stocktake-result](functional-design/RPT-11-stocktake-result.md)
+
+**🗄️ データモデル:**
+- [03-transaction-tables](data-model/03-transaction-tables.md)
+
+**🧪 テスト仕様:**
+- [TST-INV-inventory](test-specifications/TST-INV-inventory.md)
+
+### 出荷管理 (Outbound Management)
+
+**📝 要件定義:**
+- [04-outbound-management](functional-requirements/04-outbound-management.md)
+
+**🔌 API設計:**
+- [API-08-outbound](functional-design/API-08-outbound.md)
+
+**🖥️ 画面設計:**
+- [SCR-10-outbound](functional-design/SCR-10-outbound.md)
+
+**📊 帳票設計:**
+- [RPT-12-picking-instruction](functional-design/RPT-12-picking-instruction.md)
+- [RPT-13-shipping-inspection](functional-design/RPT-13-shipping-inspection.md)
+- [RPT-14-delivery-list](functional-design/RPT-14-delivery-list.md)
+- [RPT-15-unshipped-realtime](functional-design/RPT-15-unshipped-realtime.md)
+- [RPT-16-unshipped-confirmed](functional-design/RPT-16-unshipped-confirmed.md)
+
+**🔗 I/F設計:**
+- [IF-02-order](functional-design/IF-02-order.md)
+
+**🗄️ データモデル:**
+- [03-transaction-tables](data-model/03-transaction-tables.md)
+
+**🧪 テスト仕様:**
+- [TST-OUT-outbound](test-specifications/TST-OUT-outbound.md)
+
+### 在庫引当 (Stock Allocation)
+
+**📝 要件定義:**
+- [04a-allocation](functional-requirements/04a-allocation.md)
+
+**🔌 API設計:**
+- [API-12-allocation](functional-design/API-12-allocation.md)
+
+**🖥️ 画面設計:**
+- [SCR-13-allocation](functional-design/SCR-13-allocation.md)
+
+**🗄️ データモデル:**
+- [03-transaction-tables](data-model/03-transaction-tables.md)
+
+**🧪 テスト仕様:**
+- [TST-ALL-allocation](test-specifications/TST-ALL-allocation.md)
+
+### 返品管理 (Returns Management)
+
+**📝 要件定義:**
+- [08-returns](functional-requirements/08-returns.md)
+
+**🔌 API設計:**
+- [API-13-returns](functional-design/API-13-returns.md)
+
+**🖥️ 画面設計:**
+- [SCR-14-returns](functional-design/SCR-14-returns.md)
+
+**📊 帳票設計:**
+- [RPT-18-returns](functional-design/RPT-18-returns.md)
+
+**🗄️ データモデル:**
+- [03-transaction-tables](data-model/03-transaction-tables.md)
+
+**🧪 テスト仕様:**
+- [TST-RTN-returns](test-specifications/TST-RTN-returns.md)
+
+### バッチ処理 (Batch Processing)
+
+**📝 要件定義:**
+- [06-batch-processing](functional-requirements/06-batch-processing.md)
+
+**🔌 API設計:**
+- [API-09-batch](functional-design/API-09-batch.md)
+
+**🖥️ 画面設計:**
+- [SCR-11-batch](functional-design/SCR-11-batch.md)
+
+**⚙️ バッチ設計:**
+- [BAT-01-daily-close](functional-design/BAT-01-daily-close.md)
+
+**🗄️ データモデル:**
+- [04-batch-tables](data-model/04-batch-tables.md)
+
+**🧪 テスト仕様:**
+- [TST-BAT-batch](test-specifications/TST-BAT-batch.md)
+
+### レポート共通 (Reporting (Common))
+
+**📝 要件定義:**
+- [05-reports](functional-requirements/05-reports.md)
+
+**🔌 API設計:**
+- [API-10-report](functional-design/API-10-report.md)
+
+**📊 帳票設計:**
+- [RPT-17-daily-summary](functional-design/RPT-17-daily-summary.md)
+
+**🧪 テスト仕様:**
+- [TST-RPT-reports](test-specifications/TST-RPT-reports.md)
+
+### 外部連携I/F (External Interface)
+
+**📝 要件定義:**
+- [07-interface](functional-requirements/07-interface.md)
+
+**🖥️ 画面設計:**
+- [SCR-15-interface](functional-design/SCR-15-interface.md)
+
+**🧪 テスト仕様:**
+- [TST-IF-interface](test-specifications/TST-IF-interface.md)
+
+**🏗️ アーキテクチャ:**
+- [09-interface-architecture](architecture-blueprint/09-interface-architecture.md)
+
+## 横断的関心事 (Cross-Cutting Concerns)
+
+全モジュールに共通して参照されるドキュメント。
+
+### 全体アーキテクチャ (Overall Architecture)
+
+- [01-overall-architecture](architecture-blueprint/01-overall-architecture.md)
+- [02-system-architecture](architecture-design/02-system-architecture.md)
+
+### フロントエンド基盤 (Frontend Architecture)
+
+- [03-frontend-architecture](architecture-blueprint/03-frontend-architecture.md)
+
+### バックエンド基盤 (Backend Architecture)
+
+- [04-backend-architecture](architecture-blueprint/04-backend-architecture.md)
+
+### データベース基盤 (Database Architecture)
+
+- [05-database-architecture](architecture-blueprint/05-database-architecture.md)
+- [05-database-architecture](architecture-design/05-database-architecture.md)
+- [01-overview](data-model/01-overview.md)
+
+### インフラ基盤 (Infrastructure Architecture)
+
+- [06-infrastructure-architecture](architecture-blueprint/06-infrastructure-architecture.md)
+- [06-infrastructure-architecture](architecture-design/06-infrastructure-architecture.md)
+
+### セキュリティ (Security)
+
+- [07-auth-architecture](architecture-blueprint/07-auth-architecture.md)
+- [10-security-architecture](architecture-blueprint/10-security-architecture.md)
+
+### アプリケーション共通基盤 (Common Application Infrastructure)
+
+- [08-common-infrastructure](architecture-blueprint/08-common-infrastructure.md)
+- [08-common-infrastructure](architecture-design/08-common-infrastructure.md)
+
+### 監視・運用 (Monitoring & Operations)
+
+- [11-monitoring-operations](architecture-blueprint/11-monitoring-operations.md)
+- [11-monitoring-operations](architecture-design/11-monitoring-operations.md)
+
+### 開発・デプロイ (Development & Deployment)
+
+- [12-development-deploy](architecture-blueprint/12-development-deploy.md)
+- [12-development-deploy](architecture-design/12-development-deploy.md)
+
+### 非機能要件 (Non-Functional Requirements)
+
+- [13-non-functional-requirements](architecture-blueprint/13-non-functional-requirements.md)
+- [13-non-functional-requirements](architecture-design/13-non-functional-requirements.md)
+
+### テスト計画 (Test Plan)
+
+- [00-test-plan](test-specifications/00-test-plan.md)
+
+### 設計標準テンプレート (Design Standards & Templates)
+
+- [_standard-api](functional-design/_standard-api.md)
+- [_standard-screen](functional-design/_standard-screen.md)
+- [_standard-report](functional-design/_standard-report.md)
+- [_id-registry](functional-design/_id-registry.md)
+- [01-test-template](test-specifications/01-test-template.md)
+- [ARCHITECTURE-RULES](ARCHITECTURE-RULES.md)

--- a/docs/document-map.yaml
+++ b/docs/document-map.yaml
@@ -1,0 +1,323 @@
+# ============================================================================
+# WMS ShowCase — ドキュメント関連マップ (Document Relationship Map)
+# ============================================================================
+# このファイルが SSOT。docs/document-map.md は build-docs.js で自動生成される。
+#
+# 構造:
+#   modules[]        — 業務モジュール（機能単位）
+#   cross-cutting[]  — 横断的関心事（アーキテクチャ・共通基盤）
+#
+# 各モジュールの docs キー:
+#   requirements  — 機能要件定義書 (functional-requirements/)
+#   api           — API設計書 (functional-design/API-*)
+#   screen        — 画面設計書 (functional-design/SCR-*)
+#   report        — 帳票設計書 (functional-design/RPT-*)
+#   batch         — バッチ設計書 (functional-design/BAT-*)
+#   interface     — I/F設計書 (functional-design/IF-*)
+#   data-model    — データモデル (data-model/)
+#   test          — テスト仕様書 (test-specifications/)
+#   architecture  — 関連アーキテクチャ (architecture-blueprint/, architecture-design/)
+# ============================================================================
+
+modules:
+  # ──────────────────────────────────────────────────────────────────────────
+  - id: auth
+    name: 認証・認可
+    name_en: Authentication & Authorization
+    docs:
+      requirements:
+        - functional-requirements/00-authentication.md
+      api:
+        - functional-design/API-01-auth.md
+      screen:
+        - functional-design/SCR-01-auth.md
+      data-model:
+        - data-model/02-master-tables.md          # users, roles
+      test:
+        - test-specifications/TST-AUTH-login-password.md
+      architecture:
+        - architecture-blueprint/07-auth-architecture.md
+        - architecture-blueprint/10-security-architecture.md
+
+  # ──────────────────────────────────────────────────────────────────────────
+  - id: master
+    name: マスタ管理
+    name_en: Master Management
+    docs:
+      requirements:
+        - functional-requirements/01-master-management.md
+      api:
+        - functional-design/API-02-master-facility.md
+        - functional-design/API-03-master-partner.md
+        - functional-design/API-04-master-product.md
+        - functional-design/API-05-master-user.md
+      screen:
+        - functional-design/SCR-02-master-facility.md
+        - functional-design/SCR-03-master-partner.md
+        - functional-design/SCR-04-master-warehouse.md
+        - functional-design/SCR-05-master-product.md
+        - functional-design/SCR-06-master-user.md
+      data-model:
+        - data-model/02-master-tables.md
+      test:
+        - test-specifications/TST-MST-master-management.md
+
+  # ──────────────────────────────────────────────────────────────────────────
+  - id: system-parameters
+    name: システムパラメータ
+    name_en: System Parameters
+    docs:
+      requirements:
+        - functional-requirements/01a-system-parameters.md
+      api:
+        - functional-design/API-11-system-parameters.md
+      screen:
+        - functional-design/SCR-12-system-parameters.md
+      data-model:
+        - data-model/02-master-tables.md          # system_parameters
+      test:
+        - test-specifications/TST-SYS-parameters.md
+
+  # ──────────────────────────────────────────────────────────────────────────
+  - id: inbound
+    name: 入荷管理
+    name_en: Inbound Management
+    docs:
+      requirements:
+        - functional-requirements/02-inbound-management.md
+      api:
+        - functional-design/API-06-inbound.md
+      screen:
+        - functional-design/SCR-07-inbound.md
+      report:
+        - functional-design/RPT-01-inbound-inspection.md
+        - functional-design/RPT-03-inbound-plan.md
+        - functional-design/RPT-04-inbound-result.md
+        - functional-design/RPT-05-unreceived-realtime.md
+        - functional-design/RPT-06-unreceived-confirmed.md
+      interface:
+        - functional-design/IF-01-inbound-plan.md
+      data-model:
+        - data-model/03-transaction-tables.md     # inbound_orders, inbound_order_details
+      test:
+        - test-specifications/TST-INB-inbound.md
+
+  # ──────────────────────────────────────────────────────────────────────────
+  - id: inventory
+    name: 在庫管理
+    name_en: Inventory Management
+    docs:
+      requirements:
+        - functional-requirements/03-inventory-management.md
+      api:
+        - functional-design/API-07-inventory.md
+      screen:
+        - functional-design/SCR-08-inventory-ops.md
+        - functional-design/SCR-09-inventory-stocktake.md
+      report:
+        - functional-design/RPT-07-inventory.md
+        - functional-design/RPT-08-inventory-transition.md
+        - functional-design/RPT-09-inventory-correction.md
+        - functional-design/RPT-10-stocktake-list.md
+        - functional-design/RPT-11-stocktake-result.md
+      data-model:
+        - data-model/03-transaction-tables.md     # inventories, inventory_histories, stocktakes
+      test:
+        - test-specifications/TST-INV-inventory.md
+
+  # ──────────────────────────────────────────────────────────────────────────
+  - id: outbound
+    name: 出荷管理
+    name_en: Outbound Management
+    docs:
+      requirements:
+        - functional-requirements/04-outbound-management.md
+      api:
+        - functional-design/API-08-outbound.md
+      screen:
+        - functional-design/SCR-10-outbound.md
+      report:
+        - functional-design/RPT-12-picking-instruction.md
+        - functional-design/RPT-13-shipping-inspection.md
+        - functional-design/RPT-14-delivery-list.md
+        - functional-design/RPT-15-unshipped-realtime.md
+        - functional-design/RPT-16-unshipped-confirmed.md
+      interface:
+        - functional-design/IF-02-order.md
+      data-model:
+        - data-model/03-transaction-tables.md     # outbound_orders, outbound_order_details
+      test:
+        - test-specifications/TST-OUT-outbound.md
+
+  # ──────────────────────────────────────────────────────────────────────────
+  - id: allocation
+    name: 在庫引当
+    name_en: Stock Allocation
+    docs:
+      requirements:
+        - functional-requirements/04a-allocation.md
+      api:
+        - functional-design/API-12-allocation.md
+      screen:
+        - functional-design/SCR-13-allocation.md
+      data-model:
+        - data-model/03-transaction-tables.md     # allocations
+      test:
+        - test-specifications/TST-ALL-allocation.md
+
+  # ──────────────────────────────────────────────────────────────────────────
+  - id: returns
+    name: 返品管理
+    name_en: Returns Management
+    docs:
+      requirements:
+        - functional-requirements/08-returns.md
+      api:
+        - functional-design/API-13-returns.md
+      screen:
+        - functional-design/SCR-14-returns.md
+      report:
+        - functional-design/RPT-18-returns.md
+      data-model:
+        - data-model/03-transaction-tables.md     # returns
+      test:
+        - test-specifications/TST-RTN-returns.md
+
+  # ──────────────────────────────────────────────────────────────────────────
+  - id: batch
+    name: バッチ処理
+    name_en: Batch Processing
+    docs:
+      requirements:
+        - functional-requirements/06-batch-processing.md
+      api:
+        - functional-design/API-09-batch.md
+      screen:
+        - functional-design/SCR-11-batch.md
+      batch:
+        - functional-design/BAT-01-daily-close.md
+      data-model:
+        - data-model/04-batch-tables.md
+      test:
+        - test-specifications/TST-BAT-batch.md
+
+  # ──────────────────────────────────────────────────────────────────────────
+  - id: report
+    name: レポート共通
+    name_en: Reporting (Common)
+    docs:
+      requirements:
+        - functional-requirements/05-reports.md
+      api:
+        - functional-design/API-10-report.md
+      report:
+        - functional-design/RPT-17-daily-summary.md
+      test:
+        - test-specifications/TST-RPT-reports.md
+
+  # ──────────────────────────────────────────────────────────────────────────
+  - id: interface
+    name: 外部連携I/F
+    name_en: External Interface
+    docs:
+      requirements:
+        - functional-requirements/07-interface.md
+      screen:
+        - functional-design/SCR-15-interface.md
+      test:
+        - test-specifications/TST-IF-interface.md
+      architecture:
+        - architecture-blueprint/09-interface-architecture.md
+
+# ============================================================================
+# 横断的関心事 (Cross-Cutting Concerns)
+# ============================================================================
+# 全モジュールに共通して参照されるアーキテクチャ・基盤ドキュメント。
+# 特定モジュールとの強い関連は modules[].docs.architecture に記載。
+
+cross-cutting:
+  - id: overall-architecture
+    name: 全体アーキテクチャ
+    name_en: Overall Architecture
+    docs:
+      - architecture-blueprint/01-overall-architecture.md
+      - architecture-design/02-system-architecture.md
+
+  - id: frontend
+    name: フロントエンド基盤
+    name_en: Frontend Architecture
+    docs:
+      - architecture-blueprint/03-frontend-architecture.md
+
+  - id: backend
+    name: バックエンド基盤
+    name_en: Backend Architecture
+    docs:
+      - architecture-blueprint/04-backend-architecture.md
+
+  - id: database
+    name: データベース基盤
+    name_en: Database Architecture
+    docs:
+      - architecture-blueprint/05-database-architecture.md
+      - architecture-design/05-database-architecture.md
+      - data-model/01-overview.md
+
+  - id: infrastructure
+    name: インフラ基盤
+    name_en: Infrastructure Architecture
+    docs:
+      - architecture-blueprint/06-infrastructure-architecture.md
+      - architecture-design/06-infrastructure-architecture.md
+
+  - id: security
+    name: セキュリティ
+    name_en: Security
+    docs:
+      - architecture-blueprint/07-auth-architecture.md
+      - architecture-blueprint/10-security-architecture.md
+
+  - id: common-infra
+    name: アプリケーション共通基盤
+    name_en: Common Application Infrastructure
+    docs:
+      - architecture-blueprint/08-common-infrastructure.md
+      - architecture-design/08-common-infrastructure.md
+
+  - id: monitoring
+    name: 監視・運用
+    name_en: Monitoring & Operations
+    docs:
+      - architecture-blueprint/11-monitoring-operations.md
+      - architecture-design/11-monitoring-operations.md
+
+  - id: dev-deploy
+    name: 開発・デプロイ
+    name_en: Development & Deployment
+    docs:
+      - architecture-blueprint/12-development-deploy.md
+      - architecture-design/12-development-deploy.md
+
+  - id: nfr
+    name: 非機能要件
+    name_en: Non-Functional Requirements
+    docs:
+      - architecture-blueprint/13-non-functional-requirements.md
+      - architecture-design/13-non-functional-requirements.md
+
+  - id: test-plan
+    name: テスト計画
+    name_en: Test Plan
+    docs:
+      - test-specifications/00-test-plan.md
+
+  - id: standards
+    name: 設計標準テンプレート
+    name_en: Design Standards & Templates
+    docs:
+      - functional-design/_standard-api.md
+      - functional-design/_standard-screen.md
+      - functional-design/_standard-report.md
+      - functional-design/_id-registry.md
+      - test-specifications/01-test-template.md
+      - ARCHITECTURE-RULES.md

--- a/docs/scripts/build-docs.js
+++ b/docs/scripts/build-docs.js
@@ -1259,6 +1259,239 @@ async function validate() {
   return errors > 0 ? 1 : 0;
 }
 
+// ─── Document Map Generator (YAML → Markdown) ──────────────────────────────
+
+const DOCUMENT_MAP_YAML = path.join(DOCS_DIR, 'document-map.yaml');
+const DOCUMENT_MAP_MD   = path.join(DOCS_DIR, 'document-map.md');
+
+/**
+ * Minimal YAML parser for document-map.yaml.
+ * Handles the specific structure: modules[] and cross-cutting[] with nested docs.
+ */
+function parseDocumentMapYaml(yamlText) {
+  const lines = yamlText.split('\n');
+  const result = { modules: [], 'cross-cutting': [] };
+
+  let currentList = null;   // 'modules' or 'cross-cutting'
+  let currentItem = null;   // current module/cross-cutting entry
+  let currentDocs = null;   // current docs object (for modules)
+  let currentDocKey = null;  // current doc category key
+  let currentDocList = null; // current doc list (for cross-cutting)
+
+  for (const rawLine of lines) {
+    // Skip comments and empty lines
+    if (rawLine.match(/^\s*#/) || rawLine.trim() === '') continue;
+
+    const indent = rawLine.search(/\S/);
+    const line = rawLine.trim();
+
+    // Top-level keys
+    if (indent === 0 && line === 'modules:') {
+      currentList = 'modules';
+      currentItem = null;
+      continue;
+    }
+    if (indent === 0 && line === 'cross-cutting:') {
+      currentList = 'cross-cutting';
+      currentItem = null;
+      continue;
+    }
+
+    // List item start (- id: xxx)
+    if (line.startsWith('- id:')) {
+      const id = line.replace('- id:', '').trim();
+      if (currentList === 'modules') {
+        currentItem = { id, name: '', name_en: '', docs: {} };
+        result.modules.push(currentItem);
+        currentDocs = null;
+        currentDocKey = null;
+      } else if (currentList === 'cross-cutting') {
+        currentItem = { id, name: '', name_en: '', docs: [] };
+        result['cross-cutting'].push(currentItem);
+        currentDocList = null;
+      }
+      continue;
+    }
+
+    if (!currentItem) continue;
+
+    // Scalar fields
+    const nameMatch = line.match(/^name:\s*(.+)/);
+    if (nameMatch) { currentItem.name = nameMatch[1]; continue; }
+    const nameEnMatch = line.match(/^name_en:\s*(.+)/);
+    if (nameEnMatch) { currentItem.name_en = nameEnMatch[1]; continue; }
+
+    // docs: key (for modules)
+    if (line === 'docs:') {
+      if (currentList === 'modules') {
+        currentDocs = currentItem.docs;
+      }
+      currentDocKey = null;
+      currentDocList = null;
+      continue;
+    }
+
+    // Doc category key (e.g., "requirements:", "api:")
+    if (currentList === 'modules' && currentDocs && line.endsWith(':') && !line.startsWith('-')) {
+      currentDocKey = line.replace(':', '');
+      currentDocs[currentDocKey] = [];
+      continue;
+    }
+
+    // Doc list item (- path/to/file.md)
+    if (line.startsWith('- ')) {
+      const value = line.substring(2).replace(/#.*$/, '').trim(); // strip inline comments
+      if (currentList === 'modules' && currentDocs && currentDocKey) {
+        currentDocs[currentDocKey].push(value);
+      } else if (currentList === 'cross-cutting' && currentItem) {
+        currentItem.docs.push(value);
+      }
+      continue;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Resolve display name from file path (read first heading from .md file).
+ */
+function resolveDocTitle(relPath) {
+  const absPath = path.join(DOCS_DIR, relPath);
+  if (!fs.existsSync(absPath)) return relPath;
+  try {
+    const content = fs.readFileSync(absPath, 'utf-8');
+    const match = content.match(/^#\s+(.+)/m);
+    return match ? match[1].trim() : relPath;
+  } catch { return relPath; }
+}
+
+/** Doc category labels */
+const DOC_CATEGORY_LABELS = {
+  requirements:  { ja: '要件定義',    icon: '📝' },
+  api:           { ja: 'API設計',     icon: '🔌' },
+  screen:        { ja: '画面設計',    icon: '🖥️' },
+  report:        { ja: '帳票設計',    icon: '📊' },
+  batch:         { ja: 'バッチ設計',  icon: '⚙️' },
+  interface:     { ja: 'I/F設計',     icon: '🔗' },
+  'data-model':  { ja: 'データモデル', icon: '🗄️' },
+  test:          { ja: 'テスト仕様',  icon: '🧪' },
+  architecture:  { ja: 'アーキテクチャ', icon: '🏗️' },
+};
+
+function generateDocumentMapMd(mapData) {
+  const lines = [];
+  lines.push('# ドキュメント関連マップ (Document Relationship Map)');
+  lines.push('');
+  lines.push('> **このファイルは `docs/document-map.yaml` から自動生成されています。直接編集しないでください。**');
+  lines.push('> ');
+  lines.push('> 再生成: `node docs/scripts/build-docs.js --generate-map`');
+  lines.push('');
+
+  // ── Matrix table ──
+  lines.push('## モジュール × ドキュメント種別 マトリクス');
+  lines.push('');
+  lines.push('| モジュール | 要件定義 | API設計 | 画面設計 | 帳票 | バッチ | I/F | データモデル | テスト | アーキテクチャ |');
+  lines.push('|-----------|---------|---------|---------|------|--------|-----|-------------|--------|--------------|');
+
+  const docKeys = ['requirements', 'api', 'screen', 'report', 'batch', 'interface', 'data-model', 'test', 'architecture'];
+
+  for (const mod of mapData.modules) {
+    const cells = docKeys.map(key => {
+      const files = (mod.docs[key] || []);
+      if (files.length === 0) return '—';
+      return files.map(f => {
+        const basename = path.basename(f, '.md');
+        return basename;
+      }).join(', ');
+    });
+    lines.push(`| **${mod.name}** | ${cells.join(' | ')} |`);
+  }
+
+  lines.push('');
+
+  // ── Module detail sections ──
+  lines.push('## モジュール別 詳細');
+  lines.push('');
+
+  for (const mod of mapData.modules) {
+    lines.push(`### ${mod.name} (${mod.name_en})`);
+    lines.push('');
+
+    for (const key of docKeys) {
+      const files = mod.docs[key] || [];
+      if (files.length === 0) continue;
+      const label = DOC_CATEGORY_LABELS[key] || { ja: key, icon: '📄' };
+      lines.push(`**${label.icon} ${label.ja}:**`);
+      for (const f of files) {
+        lines.push(`- [${path.basename(f, '.md')}](${f})`);
+      }
+      lines.push('');
+    }
+  }
+
+  // ── Cross-cutting concerns ──
+  lines.push('## 横断的関心事 (Cross-Cutting Concerns)');
+  lines.push('');
+  lines.push('全モジュールに共通して参照されるドキュメント。');
+  lines.push('');
+
+  for (const cc of mapData['cross-cutting']) {
+    lines.push(`### ${cc.name} (${cc.name_en})`);
+    lines.push('');
+    for (const f of cc.docs) {
+      lines.push(`- [${path.basename(f, '.md')}](${f})`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+function generateDocumentMap() {
+  if (!fs.existsSync(DOCUMENT_MAP_YAML)) {
+    console.error('❌ document-map.yaml が見つかりません');
+    process.exit(1);
+  }
+
+  const yamlText = fs.readFileSync(DOCUMENT_MAP_YAML, 'utf-8');
+  const mapData  = parseDocumentMapYaml(yamlText);
+
+  console.log(`📄 Parsed: ${mapData.modules.length} modules, ${mapData['cross-cutting'].length} cross-cutting concerns`);
+
+  // Validate file existence
+  let warnings = 0;
+  for (const mod of mapData.modules) {
+    for (const [, files] of Object.entries(mod.docs)) {
+      for (const f of files) {
+        if (!fs.existsSync(path.join(DOCS_DIR, f))) {
+          console.warn(`  ⚠ ${mod.id}: ファイルが存在しません — ${f}`);
+          warnings++;
+        }
+      }
+    }
+  }
+  for (const cc of mapData['cross-cutting']) {
+    for (const f of cc.docs) {
+      if (!fs.existsSync(path.join(DOCS_DIR, f))) {
+        console.warn(`  ⚠ ${cc.id}: ファイルが存在しません — ${f}`);
+        warnings++;
+      }
+    }
+  }
+
+  // Generate Markdown
+  const md = generateDocumentMapMd(mapData);
+  fs.writeFileSync(DOCUMENT_MAP_MD, md, 'utf-8');
+  console.log(`✓  document-map.md 生成完了 (${(Buffer.byteLength(md) / 1024).toFixed(1)} KB)`);
+
+  if (warnings > 0) {
+    console.warn(`⚠  ${warnings} 件のファイル参照警告があります`);
+  }
+
+  return mapData;
+}
+
 // ─── Entry Point ─────────────────────────────────────────────────────────────
 
 async function entry() {
@@ -1266,6 +1499,8 @@ async function entry() {
   if (args.includes('--validate')) {
     const exitCode = await validate();
     process.exit(exitCode);
+  } else if (args.includes('--generate-map')) {
+    generateDocumentMap();
   } else {
     await main();
   }


### PR DESCRIPTION
## Summary
- モジュール×ドキュメント種別の関連マップを `docs/document-map.yaml`（SSOT）として新規作成
- `node docs/scripts/build-docs.js --generate-map` で YAML → Markdown（`docs/document-map.md`）を自動生成できるようにした
- CLAUDE.md に参照ルールを追記し、実装・レビュー時に対象モジュールの関連ドキュメントを確認するフローを定義

## 変更内容
| ファイル | 内容 |
|---------|------|
| `docs/document-map.yaml` | 11モジュール + 12横断的関心事の関連マップ定義 |
| `docs/document-map.md` | YAMLから自動生成されたマトリクス表 + モジュール別詳細 |
| `docs/scripts/build-docs.js` | `--generate-map` オプション追加（自前YAMLパーサー、外部依存なし） |
| `CLAUDE.md` | ドキュメント関連マップの参照ルール追記 |

## Test plan
- [x] `node docs/scripts/build-docs.js --generate-map` でエラーなく `document-map.md` が生成される
- [x] `node docs/scripts/build-docs.js --validate` が既存バリデーションを全てパスする
- [ ] 生成された `document-map.md` のマトリクス表が正しくレンダリングされることを確認
- [ ] YAML内の全ファイルパスが実在することを確認（スクリプトの存在チェックで0警告）

🤖 Generated with [Claude Code](https://claude.com/claude-code)