### PR TITLE
横断改善: fetchリクエストのAbortController対応

### DIFF
--- a/frontend/src/composables/inbound/useInboundSlipDetail.ts
+++ b/frontend/src/composables/inbound/useInboundSlipDetail.ts
@@ -1,7 +1,8 @@
-import { ref, computed } from 'vue'
+import { ref, computed, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import { ElMessage, ElMessageBox } from 'element-plus'
+import axios from 'axios'
 import apiClient from '@/api/client'
 import { toApiError } from '@/utils/apiError'
 import type { InboundSlipDetail } from '@/api/generated/models/inbound-slip-detail'
@@ -18,6 +19,10 @@ export function useInboundSlipDetail() {
   const slip = ref<InboundSlipDetail | null>(null)
   const loading = ref(false)
   const actionLoading = ref(false)
+
+  // --- 並行リクエスト制御 ---
+  let abortController: AbortController | null = null
+  onUnmounted(() => { abortController?.abort() })
 
   const slipId = computed(() => {
     const id = route.params.id
@@ -52,11 +57,16 @@ export function useInboundSlipDetail() {
   // --- API呼び出し ---
   async function fetchDetail() {
     if (!slipId.value) return
+    abortController?.abort()
+    abortController = new AbortController()
+    const signal = abortController.signal
+
     loading.value = true
     try {
-      const res = await apiClient.get<InboundSlipDetail>(`/inbound/slips/${slipId.value}`)
+      const res = await apiClient.get<InboundSlipDetail>(`/inbound/slips/${slipId.value}`, { signal })
       slip.value = res.data
     } catch (err: unknown) {
+      if (axios.isCancel(err)) return
       const error = toApiError(err)
       if (!error.response) {
         ElMessage.error(t('error.network'))
@@ -66,7 +76,9 @@ export function useInboundSlipDetail() {
       }
       // 403/500 はインターセプターが処理済み
     } finally {
-      loading.value = false
+      if (!signal.aborted) {
+        loading.value = false
+      }
     }
   }
 

--- a/frontend/src/composables/master/useAreaForm.ts
+++ b/frontend/src/composables/master/useAreaForm.ts
@@ -1,10 +1,11 @@
-import { ref, computed } from 'vue'
+import { ref, computed, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter, useRoute } from 'vue-router'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { useForm } from 'vee-validate'
 import { toTypedSchema } from '@vee-validate/zod'
 import { z } from 'zod'
+import axios from 'axios'
 import apiClient from '@/api/client'
 import { toApiError } from '@/utils/apiError'
 import { useWarehouseStore } from '@/stores/warehouse'
@@ -90,6 +91,10 @@ export function useAreaForm() {
   const warehouseCode = ref('')
   const buildingCode = ref('')
 
+  // --- 並行リクエスト制御 ---
+  let abortController: AbortController | null = null
+  onUnmounted(() => { abortController?.abort() })
+
   async function fetchBuildings() {
     if (!warehouseStore.selectedWarehouseId) return
     try {
@@ -107,9 +112,13 @@ export function useAreaForm() {
       router.push({ name: 'area-list' })
       return
     }
+    abortController?.abort()
+    abortController = new AbortController()
+    const signal = abortController.signal
+
     initialLoading.value = true
     try {
-      const res = await apiClient.get<AreaDetail>(`/master/areas/${areaId.value}`)
+      const res = await apiClient.get<AreaDetail>(`/master/areas/${areaId.value}`, { signal })
       setValues({
         buildingId: res.data.buildingId,
         areaCode: res.data.areaCode,
@@ -121,6 +130,7 @@ export function useAreaForm() {
       warehouseCode.value = res.data.warehouseCode
       buildingCode.value = res.data.buildingCode
     } catch (err: unknown) {
+      if (axios.isCancel(err)) return
       const error = toApiError(err)
       if (error.response?.status === 404) {
         ElMessage.error(t('master.area.notFound'))
@@ -129,7 +139,9 @@ export function useAreaForm() {
         ElMessage.error(t('error.network'))
       }
     } finally {
-      initialLoading.value = false
+      if (!signal.aborted) {
+        initialLoading.value = false
+      }
     }
   }
 

--- a/frontend/src/composables/master/useBuildingForm.ts
+++ b/frontend/src/composables/master/useBuildingForm.ts
@@ -1,10 +1,11 @@
-import { ref, computed } from 'vue'
+import { ref, computed, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter, useRoute } from 'vue-router'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { useForm } from 'vee-validate'
 import { toTypedSchema } from '@vee-validate/zod'
 import { z } from 'zod'
+import axios from 'axios'
 import apiClient from '@/api/client'
 import { toApiError } from '@/utils/apiError'
 import { useWarehouseStore } from '@/stores/warehouse'
@@ -64,14 +65,22 @@ export function useBuildingForm() {
   const version = ref(0)
   const warehouseCode = ref('')
 
+  // --- 並行リクエスト制御 ---
+  let abortController: AbortController | null = null
+  onUnmounted(() => { abortController?.abort() })
+
   async function fetchBuilding() {
     if (!buildingId.value) {
       router.push({ name: 'building-list' })
       return
     }
+    abortController?.abort()
+    abortController = new AbortController()
+    const signal = abortController.signal
+
     initialLoading.value = true
     try {
-      const res = await apiClient.get<BuildingDetail>(`/master/buildings/${buildingId.value}`)
+      const res = await apiClient.get<BuildingDetail>(`/master/buildings/${buildingId.value}`, { signal })
       setValues({
         buildingCode: res.data.buildingCode,
         buildingName: res.data.buildingName,
@@ -79,6 +88,7 @@ export function useBuildingForm() {
       version.value = res.data.version
       warehouseCode.value = res.data.warehouseCode
     } catch (err: unknown) {
+      if (axios.isCancel(err)) return
       const error = toApiError(err)
       if (error.response?.status === 404) {
         ElMessage.error(t('master.building.notFound'))
@@ -87,7 +97,9 @@ export function useBuildingForm() {
         ElMessage.error(t('error.network'))
       }
     } finally {
-      initialLoading.value = false
+      if (!signal.aborted) {
+        initialLoading.value = false
+      }
     }
   }
 

--- a/frontend/src/composables/master/useLocationForm.ts
+++ b/frontend/src/composables/master/useLocationForm.ts
@@ -1,10 +1,11 @@
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter, useRoute } from 'vue-router'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { useForm } from 'vee-validate'
 import { toTypedSchema } from '@vee-validate/zod'
 import { z } from 'zod'
+import axios from 'axios'
 import apiClient from '@/api/client'
 import { toApiError } from '@/utils/apiError'
 import { useWarehouseStore } from '@/stores/warehouse'
@@ -72,6 +73,10 @@ export function useLocationForm() {
   const warehouseCode = ref('')
   const areaCode = ref('')
 
+  // --- 並行リクエスト制御 ---
+  let abortController: AbortController | null = null
+  onUnmounted(() => { abortController?.abort() })
+
   // 選択中のエリア情報
   const selectedArea = computed(() =>
     areas.value.find((a) => a.id === areaId.value) ?? null,
@@ -107,9 +112,13 @@ export function useLocationForm() {
       router.push({ name: 'location-list' })
       return
     }
+    abortController?.abort()
+    abortController = new AbortController()
+    const signal = abortController.signal
+
     initialLoading.value = true
     try {
-      const res = await apiClient.get<LocationFullDetail>(`/master/locations/${locationId.value}`)
+      const res = await apiClient.get<LocationFullDetail>(`/master/locations/${locationId.value}`, { signal })
       setValues({
         areaId: res.data.areaId,
         locationCode: res.data.locationCode,
@@ -119,6 +128,7 @@ export function useLocationForm() {
       warehouseCode.value = res.data.warehouseCode
       areaCode.value = res.data.areaCode
     } catch (err: unknown) {
+      if (axios.isCancel(err)) return
       const error = toApiError(err)
       if (error.response?.status === 404) {
         ElMessage.error(t('master.location.notFound'))
@@ -127,7 +137,9 @@ export function useLocationForm() {
         ElMessage.error(t('error.network'))
       }
     } finally {
-      initialLoading.value = false
+      if (!signal.aborted) {
+        initialLoading.value = false
+      }
     }
   }
 

--- a/frontend/src/composables/master/usePartnerForm.ts
+++ b/frontend/src/composables/master/usePartnerForm.ts
@@ -1,10 +1,11 @@
-import { ref, computed } from 'vue'
+import { ref, computed, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter, useRoute } from 'vue-router'
 import { ElMessage } from 'element-plus'
 import { useForm } from 'vee-validate'
 import { toTypedSchema } from '@vee-validate/zod'
 import { z } from 'zod'
+import axios from 'axios'
 import apiClient from '@/api/client'
 import { toApiError } from '@/utils/apiError'
 import type { PartnerDetail } from '@/api/generated/models/partner-detail'
@@ -108,6 +109,10 @@ export function usePartnerForm() {
   const initialLoading = ref(false)
   const version = ref(0)
 
+  // --- 並行リクエスト制御 ---
+  let abortController: AbortController | null = null
+  onUnmounted(() => { abortController?.abort() })
+
   // --- API呼び出し ---
   async function checkCodeExists() {
     if (isEdit.value) return
@@ -131,9 +136,13 @@ export function usePartnerForm() {
       router.push({ name: 'partner-list' })
       return
     }
+    abortController?.abort()
+    abortController = new AbortController()
+    const signal = abortController.signal
+
     initialLoading.value = true
     try {
-      const res = await apiClient.get<PartnerDetail>(`/master/partners/${partnerId.value}`)
+      const res = await apiClient.get<PartnerDetail>(`/master/partners/${partnerId.value}`, { signal })
       setValues({
         partnerCode: res.data.partnerCode,
         partnerName: res.data.partnerName,
@@ -146,6 +155,7 @@ export function usePartnerForm() {
       })
       version.value = res.data.version
     } catch (err: unknown) {
+      if (axios.isCancel(err)) return
       const error = toApiError(err)
       if (error.response?.status === 404) {
         ElMessage.error(t('master.partner.notFound'))
@@ -154,7 +164,9 @@ export function usePartnerForm() {
         ElMessage.error(t('error.network'))
       }
     } finally {
-      initialLoading.value = false
+      if (!signal.aborted) {
+        initialLoading.value = false
+      }
     }
   }
 

--- a/frontend/src/composables/master/useProductForm.ts
+++ b/frontend/src/composables/master/useProductForm.ts
@@ -1,10 +1,11 @@
-import { ref, computed } from 'vue'
+import { ref, computed, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter, useRoute } from 'vue-router'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { useForm } from 'vee-validate'
 import { toTypedSchema } from '@vee-validate/zod'
 import { z } from 'zod'
+import axios from 'axios'
 import apiClient from '@/api/client'
 import { toApiError } from '@/utils/apiError'
 import type { ProductDetail } from '@/api/generated/models/product-detail'
@@ -120,6 +121,10 @@ export function useProductForm() {
   const version = ref(0)
   const hasInventory = ref(false)
 
+  // --- 並行リクエスト制御 ---
+  let abortController: AbortController | null = null
+  onUnmounted(() => { abortController?.abort() })
+
   // --- API呼び出し ---
   async function checkCodeExists() {
     if (isEdit.value) return
@@ -143,9 +148,13 @@ export function useProductForm() {
       router.push({ name: 'product-list' })
       return
     }
+    abortController?.abort()
+    abortController = new AbortController()
+    const signal = abortController.signal
+
     initialLoading.value = true
     try {
-      const res = await apiClient.get<ProductDetail>(`/master/products/${productId.value}`)
+      const res = await apiClient.get<ProductDetail>(`/master/products/${productId.value}`, { signal })
       setValues({
         productCode: res.data.productCode,
         productName: res.data.productName,
@@ -163,6 +172,7 @@ export function useProductForm() {
       version.value = res.data.version
       hasInventory.value = res.data.hasInventory ?? false
     } catch (err: unknown) {
+      if (axios.isCancel(err)) return
       const error = toApiError(err)
       if (error.response?.status === 404) {
         ElMessage.error(t('master.product.notFound'))
@@ -172,7 +182,9 @@ export function useProductForm() {
       }
       // 403/500 はインターセプターが処理済み
     } finally {
-      initialLoading.value = false
+      if (!signal.aborted) {
+        initialLoading.value = false
+      }
     }
   }
 

--- a/frontend/src/composables/master/useUserForm.ts
+++ b/frontend/src/composables/master/useUserForm.ts
@@ -1,10 +1,11 @@
-import { ref, computed } from 'vue'
+import { ref, computed, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter, useRoute } from 'vue-router'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { useForm } from 'vee-validate'
 import { toTypedSchema } from '@vee-validate/zod'
 import { z } from 'zod'
+import axios from 'axios'
 import apiClient from '@/api/client'
 import { toApiError } from '@/utils/apiError'
 import { useAuthStore } from '@/stores/auth'
@@ -135,6 +136,10 @@ export function useUserForm() {
   const updatedAt = ref('')
   const showPassword = ref(false)
 
+  // --- 並行リクエスト制御 ---
+  let abortController: AbortController | null = null
+  onUnmounted(() => { abortController?.abort() })
+
   async function checkCodeExists() {
     if (isEdit.value) return
     const code = userCode.value
@@ -157,9 +162,13 @@ export function useUserForm() {
       router.push({ name: 'user-list' })
       return
     }
+    abortController?.abort()
+    abortController = new AbortController()
+    const signal = abortController.signal
+
     initialLoading.value = true
     try {
-      const res = await apiClient.get<UserDetail>(`/master/users/${userId.value}`)
+      const res = await apiClient.get<UserDetail>(`/master/users/${userId.value}`, { signal })
       const data = res.data
       setValues({
         userCode: data.userCode,
@@ -174,6 +183,7 @@ export function useUserForm() {
       createdAt.value = data.createdAt
       updatedAt.value = data.updatedAt
     } catch (err: unknown) {
+      if (axios.isCancel(err)) return
       const error = toApiError(err)
       if (error.response?.status === 404) {
         ElMessage.error(t('master.user.notFound'))
@@ -182,7 +192,9 @@ export function useUserForm() {
         ElMessage.error(t('error.network'))
       }
     } finally {
-      initialLoading.value = false
+      if (!signal.aborted) {
+        initialLoading.value = false
+      }
     }
   }
 

--- a/frontend/src/composables/master/useWarehouseForm.ts
+++ b/frontend/src/composables/master/useWarehouseForm.ts
@@ -1,10 +1,11 @@
-import { ref, computed } from 'vue'
+import { ref, computed, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter, useRoute } from 'vue-router'
 import { ElMessage } from 'element-plus'
 import { useForm } from 'vee-validate'
 import { toTypedSchema } from '@vee-validate/zod'
 import { z } from 'zod'
+import axios from 'axios'
 import apiClient from '@/api/client'
 import { toApiError } from '@/utils/apiError'
 
@@ -82,6 +83,10 @@ export function useWarehouseForm() {
   const initialLoading = ref(false)
   const version = ref(0)
 
+  // --- 並行リクエスト制御 ---
+  let abortController: AbortController | null = null
+  onUnmounted(() => { abortController?.abort() })
+
   // --- API呼び出し ---
   async function checkCodeExists() {
     if (isEdit.value) return // 編集モードではコードチェック不要（変更不可）
@@ -105,6 +110,10 @@ export function useWarehouseForm() {
       router.push({ name: 'warehouse-list' })
       return
     }
+    abortController?.abort()
+    abortController = new AbortController()
+    const signal = abortController.signal
+
     initialLoading.value = true
     try {
       const res = await apiClient.get<{
@@ -113,7 +122,7 @@ export function useWarehouseForm() {
         warehouseNameKana: string
         address: string | null
         version: number
-      }>(`/master/warehouses/${warehouseId.value}`)
+      }>(`/master/warehouses/${warehouseId.value}`, { signal })
       setValues({
         warehouseCode: res.data.warehouseCode,
         warehouseName: res.data.warehouseName,
@@ -122,6 +131,7 @@ export function useWarehouseForm() {
       })
       version.value = res.data.version
     } catch (err: unknown) {
+      if (axios.isCancel(err)) return
       const error = toApiError(err)
       if (error.response?.status === 404) {
         ElMessage.error(t('master.warehouse.notFound'))
@@ -131,7 +141,9 @@ export function useWarehouseForm() {
       }
       // 403/500 はインターセプターが処理済み
     } finally {
-      initialLoading.value = false
+      if (!signal.aborted) {
+        initialLoading.value = false
+      }
     }
   }
 

--- a/frontend/src/composables/outbound/useOutboundSlipDetail.ts
+++ b/frontend/src/composables/outbound/useOutboundSlipDetail.ts
@@ -1,7 +1,8 @@
-import { ref, computed } from 'vue'
+import { ref, computed, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import { ElMessage, ElMessageBox } from 'element-plus'
+import axios from 'axios'
 import apiClient from '@/api/client'
 import { toApiError } from '@/utils/apiError'
 import type { OutboundSlipDetail } from '@/api/generated/models/outbound-slip-detail'
@@ -17,6 +18,10 @@ export function useOutboundSlipDetail() {
   const slip = ref<OutboundSlipDetail | null>(null)
   const loading = ref(false)
   const actionLoading = ref(false)
+
+  // --- 並行リクエスト制御 ---
+  let abortController: AbortController | null = null
+  onUnmounted(() => { abortController?.abort() })
 
   const slipId = computed(() => {
     const id = route.params.id
@@ -58,11 +63,16 @@ export function useOutboundSlipDetail() {
       router.push({ name: 'outbound-slip-list' })
       return
     }
+    abortController?.abort()
+    abortController = new AbortController()
+    const signal = abortController.signal
+
     loading.value = true
     try {
-      const res = await apiClient.get<OutboundSlipDetail>(`/outbound/slips/${slipId.value}`)
+      const res = await apiClient.get<OutboundSlipDetail>(`/outbound/slips/${slipId.value}`, { signal })
       slip.value = res.data
     } catch (err: unknown) {
+      if (axios.isCancel(err)) return
       const error = toApiError(err)
       if (!error.response) {
         ElMessage.error(t('error.network'))
@@ -72,7 +82,9 @@ export function useOutboundSlipDetail() {
       }
       // 403/500 はインターセプターが処理済み
     } finally {
-      loading.value = false
+      if (!signal.aborted) {
+        loading.value = false
+      }
     }
   }
 


### PR DESCRIPTION
Closes #155

## Summary
- Form composables（7ファイル）にAbortController + onUnmounted を追加
  - useWarehouseForm, usePartnerForm, useProductForm, useAreaForm, useBuildingForm, useLocationForm, useUserForm
- Detail composables（2ファイル）にAbortController + onUnmounted を追加
  - useInboundSlipDetail, useOutboundSlipDetail
- 既存のList composables（18ファイル）と同一パターンを踏襲
- Auth composables（4ファイル）はワンショット認証呼び出しのため対象外

## 変更パターン
各fetch系メソッドに以下を統一的に適用:
1. `abortController?.abort()` で前のリクエストをキャンセル
2. `new AbortController()` で新しいcontrollerを作成
3. `{ signal }` をaxiosリクエストに渡す
4. `axios.isCancel(err)` でキャンセル検知し早期return
5. `if (!signal.aborted)` でloading状態の不整合を防止
6. `onUnmounted(() => { abortController?.abort() })` でクリーンアップ

## Test coverage
フロントエンドのみの変更のため、バックエンドテストカバレッジへの影響なし。
TypeScript型チェック・Viteビルド通過を確認済み。

## Test plan
- [x] `vue-tsc --noEmit` でTypeScript型チェック通過
- [x] `vite build` でビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)