### PR TITLE
API-07 storageCondition の参照テーブルを areas に修正

### DIFF
--- a/docs/functional-design/API-07-inventory.md
+++ b/docs/functional-design/API-07-inventory.md
@@ -235,7 +235,7 @@ flowchart TD
 ### 5. 補足事項
 
 - `locationCodePrefix` は `LIKE 'A-01%'` として適用する（前方一致）。
-- `storageCondition` は `locations` テーブルの `storage_condition` カラムを JOIN して絞り込む。
+- `storageCondition` は `areas` テーブルの `storage_condition` カラムを JOIN して絞り込む（`locations` → `areas` → `areas.storage_condition`）。
 - `viewType=PRODUCT_SUMMARY` の `totalPieceEquivalent` は `products.case_quantity` および `products.ball_quantity` を参照して算出する。
 - ソートのデフォルトは `locationCode,asc`（LOCATION時）/ `productCode,asc`（PRODUCT_SUMMARY時）。
 


### PR DESCRIPTION
Closes #201

## Summary
- API-07-inventory.md INV-001 補足事項の `storageCondition` フィルタ記述を修正
- `locations` テーブル → `areas` テーブルに修正（実データモデルに合わせる）
- JOINパス（`locations` → `areas` → `areas.storage_condition`）を明記

🤖 Generated with [Claude Code](https://claude.com/claude-code)