### PR TITLE
fix: terraform apply エラー修正（ACR名・PostgreSQL VNet）

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -132,7 +132,7 @@ terraform destroy
 
 ### 常設リソース（destroyされない）
 
-- ACR（`acrwms`） — `lifecycle { prevent_destroy = true }`
+- ACR（`acrwmsdevshowcase`） — `lifecycle { prevent_destroy = true }`
 - Terraform state Storage Account（`stwmsterraform`）
 
 ---

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -56,6 +56,7 @@ module "vnet" {
 
 module "acr" {
   source      = "../../modules/acr"
+  acr_name    = var.acr_name
   location    = var.location
   common_tags = local.common_tags
 }

--- a/infra/environments/dev/terraform.tfvars
+++ b/infra/environments/dev/terraform.tfvars
@@ -2,6 +2,7 @@
 # subscription_id is set via environment variable: TF_VAR_subscription_id
 environment = "dev"
 location    = "japaneast"
+acr_name    = "acrwmsdevshowcase"
 
 # Container Apps
 min_replicas = 0

--- a/infra/environments/dev/variables.tf
+++ b/infra/environments/dev/variables.tf
@@ -3,6 +3,11 @@ variable "environment" {
   type        = string
 }
 
+variable "acr_name" {
+  description = "Globally unique name for the Azure Container Registry"
+  type        = string
+}
+
 variable "location" {
   description = "Azure region"
   type        = string

--- a/infra/environments/prd/main.tf
+++ b/infra/environments/prd/main.tf
@@ -120,6 +120,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "postgres_west" {
 
 module "acr" {
   source      = "../../modules/acr"
+  acr_name    = var.acr_name
   location    = var.location_primary
   common_tags = local.common_tags
 }

--- a/infra/environments/prd/terraform.tfvars
+++ b/infra/environments/prd/terraform.tfvars
@@ -1,6 +1,7 @@
 # environments/prd/terraform.tfvars
 # subscription_id is set via environment variable: TF_VAR_subscription_id
 environment        = "prd"
+acr_name           = "acrwmsprdshowcase"
 location_primary   = "japaneast"
 location_secondary = "japanwest"
 

--- a/infra/environments/prd/variables.tf
+++ b/infra/environments/prd/variables.tf
@@ -3,6 +3,11 @@ variable "environment" {
   type        = string
 }
 
+variable "acr_name" {
+  description = "Globally unique name for the Azure Container Registry"
+  type        = string
+}
+
 variable "location_primary" {
   description = "Primary Azure region (Japan East)"
   type        = string

--- a/infra/modules/acr/main.tf
+++ b/infra/modules/acr/main.tf
@@ -5,7 +5,7 @@ resource "azurerm_resource_group" "acr" {
 }
 
 resource "azurerm_container_registry" "main" {
-  name                = "acrwms"
+  name                = var.acr_name
   resource_group_name = azurerm_resource_group.acr.name
   location            = azurerm_resource_group.acr.location
   sku                 = "Basic"

--- a/infra/modules/acr/variables.tf
+++ b/infra/modules/acr/variables.tf
@@ -1,3 +1,8 @@
+variable "acr_name" {
+  description = "Globally unique name for the Azure Container Registry"
+  type        = string
+}
+
 variable "location" {
   description = "Azure region"
   type        = string

--- a/infra/modules/postgresql/main.tf
+++ b/infra/modules/postgresql/main.tf
@@ -12,8 +12,9 @@ resource "azurerm_postgresql_flexible_server" "main" {
   administrator_password       = var.db_admin_password
   zone                         = "1"
 
-  delegated_subnet_id = var.snet_pg_id
-  private_dns_zone_id = var.private_dns_zone_id
+  public_network_access_enabled = false
+  delegated_subnet_id           = var.snet_pg_id
+  private_dns_zone_id           = var.private_dns_zone_id
 
   tags = var.common_tags
 }


### PR DESCRIPTION
## Summary
- ACR名をモジュール変数化（グローバル名 `acrwms` が重複していたため）
  - dev: `acrwmsdevshowcase`
  - prd: `acrwmsprdshowcase`
- PostgreSQL に `public_network_access_enabled = false` を明示（VNet delegated subnet 使用時に必須）

## 手動対応が別途必要
wms-dev サブスクリプションでリソースプロバイダーの登録が必要：
```bash
az provider register --namespace Microsoft.Communication
az provider register --namespace Microsoft.App
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)