### PR TITLE
fix: terraform apply エラー修正2（log_timezone・初期イメージ）

### DIFF
--- a/infra/environments/dev/terraform.tfvars
+++ b/infra/environments/dev/terraform.tfvars
@@ -6,7 +6,7 @@ location    = "japaneast"
 # Container Apps
 min_replicas = 0
 max_replicas = 3
-image_tag    = "sha-latest"
+image_tag    = "init"
 log_level    = "DEBUG"
 
 # PostgreSQL

--- a/infra/modules/container-apps/main.tf
+++ b/infra/modules/container-apps/main.tf
@@ -49,7 +49,7 @@ resource "azurerm_container_app" "backend" {
 
     container {
       name   = "wms-backend"
-      image  = "${var.acr_login_server}/wms-backend:${var.image_tag}"
+      image  = var.image_tag == "init" ? "mcr.microsoft.com/azuredocs/containerapps-helloworld:latest" : "${var.acr_login_server}/wms-backend:${var.image_tag}"
       cpu    = 0.5
       memory = "1Gi"
 

--- a/infra/modules/postgresql/main.tf
+++ b/infra/modules/postgresql/main.tf
@@ -31,12 +31,6 @@ resource "azurerm_postgresql_flexible_server_configuration" "timezone" {
   value     = "Asia/Tokyo"
 }
 
-resource "azurerm_postgresql_flexible_server_configuration" "log_timezone" {
-  server_id = azurerm_postgresql_flexible_server.main.id
-  name      = "log_timezone"
-  value     = "Asia/Tokyo"
-}
-
 resource "azurerm_postgresql_flexible_server_configuration" "statement_timeout" {
   server_id = azurerm_postgresql_flexible_server.main.id
   name      = "statement_timeout"


### PR DESCRIPTION
## Summary
- PostgreSQL: `log_timezone` 設定を削除（B1ms SKU では読み取り専用パラメータ）
- Container App: `image_tag = "init"` 時は Microsoft 公式ダミーイメージを使用（ACR にイメージが無い初回構築時の問題を回避）
- dev/terraform.tfvars: `image_tag` を `"init"` に変更

## 備考
初回の `terraform apply` 成功後、実際のアプリをデプロイする際は `image_tag` を `sha-{commitHash}` に変更するか、`az containerapp update` で直接イメージを更新する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)