### PR TITLE
chore: terraform destroy時の安全ガードを緩和

### DIFF
--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -11,7 +11,11 @@ terraform {
 
 provider "azurerm" {
   subscription_id = var.subscription_id
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }
 
 locals {

--- a/infra/modules/acr/main.tf
+++ b/infra/modules/acr/main.tf
@@ -13,7 +13,7 @@ resource "azurerm_container_registry" "main" {
 
   tags = var.common_tags
 
-  lifecycle {
-    prevent_destroy = true
-  }
+  # lifecycle {
+  #   prevent_destroy = true
+  # }
 }


### PR DESCRIPTION
## Summary
- ACR の `prevent_destroy` を無効化（ShowCaseプロジェクトでは destroy を頻繁に行うため）
- dev provider に `prevent_deletion_if_contains_resources = false` を追加（Application Insights が自動作成するリソースの残留でリソースグループ削除がブロックされる問題を回避）

🤖 Generated with [Claude Code](https://claude.com/claude-code)