### PR TITLE
レポートサービスのwarehouseName共通ユーティリティ化

### DIFF
--- a/backend/src/main/java/com/wms/report/service/DeliveryListReportService.java
+++ b/backend/src/main/java/com/wms/report/service/DeliveryListReportService.java
@@ -24,6 +24,7 @@ import static com.wms.report.service.CsvGenerationService.fmtInteger;
 import static com.wms.report.service.CsvGenerationService.fmtOrDash;
 import static com.wms.report.service.ReportServiceUtils.OUTBOUND_STATUS_LABELS;
 import static com.wms.report.service.ReportServiceUtils.escapeLikePattern;
+import static com.wms.report.service.ReportServiceUtils.formatWarehouseName;
 import static com.wms.report.service.ReportServiceUtils.getCurrentUserName;
 import static com.wms.report.service.ReportServiceUtils.todayFileDate;
 
@@ -72,7 +73,7 @@ public class DeliveryListReportService {
                 .orElseThrow(() -> new ResourceNotFoundException("WAREHOUSE_NOT_FOUND",
                         "倉庫が見つかりません: warehouseId=" + warehouseId));
 
-        String warehouseName = warehouse.getWarehouseName() + " (" + warehouse.getWarehouseCode() + ")";
+        String warehouseName = formatWarehouseName(warehouse);
 
         String carrierLike = carrier != null ? "%" + escapeLikePattern(carrier) + "%" : null;
 

--- a/backend/src/main/java/com/wms/report/service/InboundInspectionReportService.java
+++ b/backend/src/main/java/com/wms/report/service/InboundInspectionReportService.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import static com.wms.report.service.CsvGenerationService.fmtDate;
 import static com.wms.report.service.CsvGenerationService.fmtInteger;
 import static com.wms.report.service.CsvGenerationService.fmtOrDash;
+import static com.wms.report.service.ReportServiceUtils.formatWarehouseName;
 import static com.wms.report.service.ReportServiceUtils.getCaseQuantity;
 import static com.wms.report.service.ReportServiceUtils.getCurrentUserName;
 import static com.wms.report.service.ReportServiceUtils.loadProductMap;
@@ -63,7 +64,7 @@ public class InboundInspectionReportService {
                 "入荷検品レポート",
                 "rpt-01-inbound-inspection",
                 "inbound_inspection_" + todayFileDate(),
-                slip.getWarehouseName() + " (" + slip.getWarehouseCode() + ")",
+                formatWarehouseName(slip.getWarehouseName(), slip.getWarehouseCode()),
                 getCurrentUserName(),
                 "伝票番号: " + slip.getSlipNumber(),
                 CSV_HEADERS,

--- a/backend/src/main/java/com/wms/report/service/InboundPlanReportService.java
+++ b/backend/src/main/java/com/wms/report/service/InboundPlanReportService.java
@@ -23,6 +23,7 @@ import static com.wms.report.service.CsvGenerationService.fmtDate;
 import static com.wms.report.service.CsvGenerationService.fmtInteger;
 import static com.wms.report.service.CsvGenerationService.fmtOrDash;
 import static com.wms.report.service.ReportServiceUtils.INBOUND_STATUS_LABELS;
+import static com.wms.report.service.ReportServiceUtils.formatWarehouseName;
 import static com.wms.report.service.ReportServiceUtils.getCaseQuantity;
 import static com.wms.report.service.ReportServiceUtils.getCurrentUserName;
 import static com.wms.report.service.ReportServiceUtils.loadProductMap;
@@ -70,7 +71,7 @@ public class InboundPlanReportService {
                 "入荷予定レポート",
                 "rpt-03-inbound-plan",
                 "inbound_plan_" + todayFileDate(),
-                warehouse.getWarehouseName() + " (" + warehouse.getWarehouseCode() + ")",
+                formatWarehouseName(warehouse),
                 getCurrentUserName(),
                 conditionsSummary,
                 CSV_HEADERS,

--- a/backend/src/main/java/com/wms/report/service/InboundResultReportService.java
+++ b/backend/src/main/java/com/wms/report/service/InboundResultReportService.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import static com.wms.report.service.CsvGenerationService.fmtDate;
 import static com.wms.report.service.CsvGenerationService.fmtInteger;
 import static com.wms.report.service.CsvGenerationService.fmtOrDash;
+import static com.wms.report.service.ReportServiceUtils.formatWarehouseName;
 import static com.wms.report.service.ReportServiceUtils.getCaseQuantity;
 import static com.wms.report.service.ReportServiceUtils.getCurrentUserName;
 import static com.wms.report.service.ReportServiceUtils.loadProductMap;
@@ -78,7 +79,7 @@ public class InboundResultReportService {
                 "入庫実績レポート",
                 "rpt-04-inbound-result",
                 "inbound_result_" + todayFileDate(),
-                warehouse.getWarehouseName() + " (" + warehouse.getWarehouseCode() + ")",
+                formatWarehouseName(warehouse),
                 getCurrentUserName(),
                 conditionsSummary,
                 CSV_HEADERS,

--- a/backend/src/main/java/com/wms/report/service/InventoryCorrectionReportService.java
+++ b/backend/src/main/java/com/wms/report/service/InventoryCorrectionReportService.java
@@ -27,6 +27,7 @@ import static com.wms.report.service.CsvGenerationService.fmtDate;
 import static com.wms.report.service.CsvGenerationService.fmtInteger;
 import static com.wms.report.service.CsvGenerationService.fmtOrDash;
 import static com.wms.report.service.ReportServiceUtils.JST;
+import static com.wms.report.service.ReportServiceUtils.formatWarehouseName;
 import static com.wms.report.service.ReportServiceUtils.getCurrentUserName;
 import static com.wms.report.service.ReportServiceUtils.todayFileDate;
 
@@ -82,7 +83,7 @@ public class InventoryCorrectionReportService {
                 "在庫訂正一覧",
                 "rpt-09-inventory-correction",
                 "inventory_correction_" + todayFileDate(),
-                warehouse.getWarehouseName() + " (" + warehouse.getWarehouseCode() + ")",
+                formatWarehouseName(warehouse),
                 getCurrentUserName(),
                 conditionsSummary,
                 CSV_HEADERS,

--- a/backend/src/main/java/com/wms/report/service/InventoryReportService.java
+++ b/backend/src/main/java/com/wms/report/service/InventoryReportService.java
@@ -20,6 +20,7 @@ import java.util.List;
 import static com.wms.report.service.CsvGenerationService.fmtDate;
 import static com.wms.report.service.CsvGenerationService.fmtInteger;
 import static com.wms.report.service.CsvGenerationService.fmtOrDash;
+import static com.wms.report.service.ReportServiceUtils.formatWarehouseName;
 import static com.wms.report.service.ReportServiceUtils.getCurrentUserName;
 import static com.wms.report.service.ReportServiceUtils.todayFileDate;
 
@@ -78,7 +79,7 @@ public class InventoryReportService {
                 "在庫一覧レポート",
                 "rpt-07-inventory",
                 "inventory_" + todayFileDate(),
-                warehouse.getWarehouseName() + " (" + warehouse.getWarehouseCode() + ")",
+                formatWarehouseName(warehouse),
                 getCurrentUserName(),
                 conditionsSummary,
                 CSV_HEADERS,

--- a/backend/src/main/java/com/wms/report/service/InventoryTransitionReportService.java
+++ b/backend/src/main/java/com/wms/report/service/InventoryTransitionReportService.java
@@ -25,6 +25,7 @@ import static com.wms.report.service.CsvGenerationService.fmtDate;
 import static com.wms.report.service.CsvGenerationService.fmtInteger;
 import static com.wms.report.service.CsvGenerationService.fmtOrDash;
 import static com.wms.report.service.ReportServiceUtils.JST;
+import static com.wms.report.service.ReportServiceUtils.formatWarehouseName;
 import static com.wms.report.service.ReportServiceUtils.getCurrentUserName;
 import static com.wms.report.service.ReportServiceUtils.todayFileDate;
 
@@ -95,7 +96,7 @@ public class InventoryTransitionReportService {
                 "在庫推移レポート",
                 "rpt-08-inventory-transition",
                 "inventory_transition_" + todayFileDate(),
-                warehouse.getWarehouseName() + " (" + warehouse.getWarehouseCode() + ")",
+                formatWarehouseName(warehouse),
                 getCurrentUserName(),
                 "対象商品: " + product.getProductCode() + " " + product.getProductName()
                         + " / " + conditionsSummary,

--- a/backend/src/main/java/com/wms/report/service/PickingInstructionReportService.java
+++ b/backend/src/main/java/com/wms/report/service/PickingInstructionReportService.java
@@ -22,6 +22,7 @@ import static com.wms.report.service.CsvGenerationService.fmtDate;
 import static com.wms.report.service.CsvGenerationService.fmtInteger;
 import static com.wms.report.service.CsvGenerationService.fmtOrDash;
 import static com.wms.report.service.ReportServiceUtils.PICKING_STATUS_LABELS;
+import static com.wms.report.service.ReportServiceUtils.formatWarehouseName;
 import static com.wms.report.service.ReportServiceUtils.getCurrentUserName;
 import static com.wms.report.service.ReportServiceUtils.todayFileDate;
 
@@ -69,7 +70,7 @@ public class PickingInstructionReportService {
                 .orElseThrow(() -> new ResourceNotFoundException("WAREHOUSE_NOT_FOUND",
                         "倉庫が見つかりません: warehouseId=" + instruction.getWarehouseId()));
 
-        String warehouseName = warehouse.getWarehouseName() + " (" + warehouse.getWarehouseCode() + ")";
+        String warehouseName = formatWarehouseName(warehouse);
 
         List<Object[]> rows = outboundReportRepository.findPickingInstructionReportData(pickingInstructionId);
 

--- a/backend/src/main/java/com/wms/report/service/ReportServiceUtils.java
+++ b/backend/src/main/java/com/wms/report/service/ReportServiceUtils.java
@@ -2,6 +2,7 @@ package com.wms.report.service;
 
 import com.wms.inbound.entity.InboundSlipLine;
 import com.wms.master.entity.Product;
+import com.wms.master.entity.Warehouse;
 import com.wms.master.repository.ProductRepository;
 import org.springframework.security.core.context.SecurityContextHolder;
 
@@ -68,6 +69,16 @@ final class ReportServiceUtils {
     /** 現在のJST日付をファイル名用にフォーマットする（例: "20260327"） */
     static String todayFileDate() {
         return LocalDate.now(JST).format(FILE_DATE_FMT);
+    }
+
+    /** 倉庫名を「倉庫名 (コード)」形式にフォーマットする */
+    static String formatWarehouseName(Warehouse warehouse) {
+        return warehouse.getWarehouseName() + " (" + warehouse.getWarehouseCode() + ")";
+    }
+
+    /** 倉庫名・コードから「倉庫名 (コード)」形式にフォーマットする */
+    static String formatWarehouseName(String name, String code) {
+        return name + " (" + code + ")";
     }
 
     /** SecurityContextから現在のユーザー名を取得する */

--- a/backend/src/main/java/com/wms/report/service/ReturnsReportService.java
+++ b/backend/src/main/java/com/wms/report/service/ReturnsReportService.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import static com.wms.report.service.CsvGenerationService.fmtDate;
 import static com.wms.report.service.CsvGenerationService.fmtInteger;
 import static com.wms.report.service.CsvGenerationService.fmtOrDash;
+import static com.wms.report.service.ReportServiceUtils.formatWarehouseName;
 import static com.wms.report.service.ReportServiceUtils.getCurrentUserName;
 import static com.wms.report.service.ReportServiceUtils.todayFileDate;
 
@@ -87,7 +88,7 @@ public class ReturnsReportService {
                 .orElseThrow(() -> new ResourceNotFoundException("WAREHOUSE_NOT_FOUND",
                         "倉庫が見つかりません: warehouseId=" + warehouseId));
 
-        String warehouseName = warehouse.getWarehouseName() + " (" + warehouse.getWarehouseCode() + ")";
+        String warehouseName = formatWarehouseName(warehouse);
 
         String returnTypeStr = returnType != null ? returnType.getValue() : null;
         String returnReasonStr = returnReason != null ? returnReason.getValue() : null;

--- a/backend/src/main/java/com/wms/report/service/ShippingInspectionReportService.java
+++ b/backend/src/main/java/com/wms/report/service/ShippingInspectionReportService.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import static com.wms.report.service.CsvGenerationService.fmtDate;
 import static com.wms.report.service.CsvGenerationService.fmtInteger;
 import static com.wms.report.service.CsvGenerationService.fmtOrDash;
+import static com.wms.report.service.ReportServiceUtils.formatWarehouseName;
 import static com.wms.report.service.ReportServiceUtils.getCurrentUserName;
 import static com.wms.report.service.ReportServiceUtils.todayFileDate;
 
@@ -66,7 +67,7 @@ public class ShippingInspectionReportService {
                 .orElseThrow(() -> new ResourceNotFoundException("WAREHOUSE_NOT_FOUND",
                         "倉庫が見つかりません: warehouseId=" + slip.getWarehouseId()));
 
-        String warehouseName = warehouse.getWarehouseName() + " (" + warehouse.getWarehouseCode() + ")";
+        String warehouseName = formatWarehouseName(warehouse);
 
         List<Object[]> rows = outboundReportRepository.findShippingInspectionReportData(slipId);
 

--- a/backend/src/main/java/com/wms/report/service/StocktakeListReportService.java
+++ b/backend/src/main/java/com/wms/report/service/StocktakeListReportService.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import static com.wms.report.service.CsvGenerationService.fmtDate;
 import static com.wms.report.service.CsvGenerationService.fmtInteger;
 import static com.wms.report.service.CsvGenerationService.fmtOrDash;
+import static com.wms.report.service.ReportServiceUtils.formatWarehouseName;
 import static com.wms.report.service.ReportServiceUtils.getCurrentUserName;
 import static com.wms.report.service.ReportServiceUtils.todayFileDate;
 
@@ -81,7 +82,7 @@ public class StocktakeListReportService {
             Warehouse warehouse = warehouseRepository.findById(header.getWarehouseId())
                     .orElseThrow(() -> new ResourceNotFoundException("WAREHOUSE_NOT_FOUND",
                             "倉庫が見つかりません: warehouseId=" + header.getWarehouseId()));
-            warehouseName = warehouse.getWarehouseName() + " (" + warehouse.getWarehouseCode() + ")";
+            warehouseName = formatWarehouseName(warehouse);
             conditionsSummary = "棚卸番号: " + header.getStocktakeNumber();
             if (header.getTargetDescription() != null) {
                 conditionsSummary += " / 対象: " + header.getTargetDescription();
@@ -94,7 +95,7 @@ public class StocktakeListReportService {
             Warehouse warehouse = warehouseRepository.findById(building.getWarehouseId())
                     .orElseThrow(() -> new ResourceNotFoundException("WAREHOUSE_NOT_FOUND",
                             "倉庫が見つかりません: warehouseId=" + building.getWarehouseId()));
-            warehouseName = warehouse.getWarehouseName() + " (" + warehouse.getWarehouseCode() + ")";
+            warehouseName = formatWarehouseName(warehouse);
             conditionsSummary = "棟: " + building.getBuildingName() + " (" + building.getBuildingCode() + ") [プレビュー]";
             rows = stocktakeReportRepository.findStocktakeListByBuildingId(buildingId, areaId);
         }

--- a/backend/src/main/java/com/wms/report/service/StocktakeResultReportService.java
+++ b/backend/src/main/java/com/wms/report/service/StocktakeResultReportService.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import static com.wms.report.service.CsvGenerationService.fmtInteger;
 import static com.wms.report.service.CsvGenerationService.fmtOrDash;
 import static com.wms.report.service.CsvGenerationService.fmtPercent;
+import static com.wms.report.service.ReportServiceUtils.formatWarehouseName;
 import static com.wms.report.service.ReportServiceUtils.getCurrentUserName;
 import static com.wms.report.service.ReportServiceUtils.todayFileDate;
 
@@ -72,7 +73,7 @@ public class StocktakeResultReportService {
                 .orElseThrow(() -> new ResourceNotFoundException("WAREHOUSE_NOT_FOUND",
                         "倉庫が見つかりません: warehouseId=" + header.getWarehouseId()));
 
-        String warehouseName = warehouse.getWarehouseName() + " (" + warehouse.getWarehouseCode() + ")";
+        String warehouseName = formatWarehouseName(warehouse);
 
         String conditionsSummary = buildConditionsSummary(header);
 

--- a/backend/src/main/java/com/wms/report/service/UnreceivedConfirmedReportService.java
+++ b/backend/src/main/java/com/wms/report/service/UnreceivedConfirmedReportService.java
@@ -20,6 +20,7 @@ import static com.wms.report.service.CsvGenerationService.fmtDate;
 import static com.wms.report.service.CsvGenerationService.fmtInteger;
 import static com.wms.report.service.CsvGenerationService.fmtOrDash;
 import static com.wms.report.service.ReportServiceUtils.INBOUND_STATUS_LABELS;
+import static com.wms.report.service.ReportServiceUtils.formatWarehouseName;
 import static com.wms.report.service.ReportServiceUtils.getCurrentUserName;
 import static com.wms.report.service.ReportServiceUtils.todayFileDate;
 
@@ -62,7 +63,7 @@ public class UnreceivedConfirmedReportService {
                 "未入荷リスト（確定）",
                 "rpt-06-unreceived-confirmed",
                 "unreceived_confirmed_" + todayFileDate(),
-                warehouse.getWarehouseName() + " (" + warehouse.getWarehouseCode() + ")",
+                formatWarehouseName(warehouse),
                 getCurrentUserName(),
                 "営業日基準日: " + fmtDate(batchBusinessDate) + "（日替確定）",
                 CSV_HEADERS,

--- a/backend/src/main/java/com/wms/report/service/UnreceivedRealtimeReportService.java
+++ b/backend/src/main/java/com/wms/report/service/UnreceivedRealtimeReportService.java
@@ -25,6 +25,7 @@ import static com.wms.report.service.CsvGenerationService.fmtDate;
 import static com.wms.report.service.CsvGenerationService.fmtInteger;
 import static com.wms.report.service.CsvGenerationService.fmtOrDash;
 import static com.wms.report.service.ReportServiceUtils.INBOUND_STATUS_LABELS;
+import static com.wms.report.service.ReportServiceUtils.formatWarehouseName;
 import static com.wms.report.service.ReportServiceUtils.getCaseQuantity;
 import static com.wms.report.service.ReportServiceUtils.getCurrentUserName;
 import static com.wms.report.service.ReportServiceUtils.loadProductMap;
@@ -74,7 +75,7 @@ public class UnreceivedRealtimeReportService {
                 "未入荷リスト（リアルタイム）",
                 "rpt-05-unreceived-realtime",
                 "unreceived_realtime_" + todayFileDate(),
-                warehouse.getWarehouseName() + " (" + warehouse.getWarehouseCode() + ")",
+                formatWarehouseName(warehouse),
                 getCurrentUserName(),
                 "基準日: " + fmtDate(effectiveDate),
                 CSV_HEADERS,

--- a/backend/src/main/java/com/wms/report/service/UnshippedConfirmedReportService.java
+++ b/backend/src/main/java/com/wms/report/service/UnshippedConfirmedReportService.java
@@ -21,6 +21,7 @@ import static com.wms.report.service.CsvGenerationService.fmtDate;
 import static com.wms.report.service.CsvGenerationService.fmtInteger;
 import static com.wms.report.service.CsvGenerationService.fmtOrDash;
 import static com.wms.report.service.ReportServiceUtils.OUTBOUND_STATUS_LABELS;
+import static com.wms.report.service.ReportServiceUtils.formatWarehouseName;
 import static com.wms.report.service.ReportServiceUtils.getCurrentUserName;
 import static com.wms.report.service.ReportServiceUtils.todayFileDate;
 
@@ -53,7 +54,7 @@ public class UnshippedConfirmedReportService {
                 .orElseThrow(() -> new ResourceNotFoundException("WAREHOUSE_NOT_FOUND",
                         "倉庫が見つかりません: warehouseId=" + warehouseId));
 
-        String warehouseName = warehouse.getWarehouseName() + " (" + warehouse.getWarehouseCode() + ")";
+        String warehouseName = formatWarehouseName(warehouse);
 
         List<UnshippedListRecord> records = unshippedListRecordRepository
                 .findByBatchBusinessDateAndWarehouseCodeOrderByPlannedDateAscSlipNumberAscProductCodeAsc(

--- a/backend/src/main/java/com/wms/report/service/UnshippedRealtimeReportService.java
+++ b/backend/src/main/java/com/wms/report/service/UnshippedRealtimeReportService.java
@@ -21,6 +21,7 @@ import static com.wms.report.service.CsvGenerationService.fmtDate;
 import static com.wms.report.service.CsvGenerationService.fmtInteger;
 import static com.wms.report.service.CsvGenerationService.fmtOrDash;
 import static com.wms.report.service.ReportServiceUtils.OUTBOUND_STATUS_LABELS;
+import static com.wms.report.service.ReportServiceUtils.formatWarehouseName;
 import static com.wms.report.service.ReportServiceUtils.getCurrentUserName;
 import static com.wms.report.service.ReportServiceUtils.todayFileDate;
 
@@ -62,7 +63,7 @@ public class UnshippedRealtimeReportService {
                 .orElseThrow(() -> new ResourceNotFoundException("WAREHOUSE_NOT_FOUND",
                         "倉庫が見つかりません: warehouseId=" + warehouseId));
 
-        String warehouseName = warehouse.getWarehouseName() + " (" + warehouse.getWarehouseCode() + ")";
+        String warehouseName = formatWarehouseName(warehouse);
 
         LocalDate effectiveDate = asOfDate != null ? asOfDate : businessDateProvider.today();
 


### PR DESCRIPTION
Closes #282

## Summary
- `ReportServiceUtils.formatWarehouseName()` を追加（`Warehouse` 引数版 + `String name, String code` 引数版の2オーバーロード）
- 全16レポートサービス（17箇所）の倉庫名フォーマット処理を共通メソッドに置換

## Test coverage

### Backend (JaCoCo)
| 指標 | 値 |
|------|-----|
| C0（LINE） | 100% |
| C1（BRANCH） | 100% |

※ ReportServiceUtils の新メソッドは既存テストでサービス経由でカバー済み

## Test plan
- [x] 全レポートサービスのテスト通過（1572/1573、1件の失敗は SecurityConfig の既存テストで本変更と無関係）
- [x] ReportServiceUtils カバレッジ 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)