### PR TITLE
stocktake_headers/linesにcreated_by/updated_by監査カラムを追加

### DIFF
--- a/backend/src/main/java/com/wms/inventory/entity/StocktakeHeader.java
+++ b/backend/src/main/java/com/wms/inventory/entity/StocktakeHeader.java
@@ -14,7 +14,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -74,9 +76,17 @@ public class StocktakeHeader {
     @Column(name = "created_at", nullable = false, updatable = false)
     private OffsetDateTime createdAt;
 
+    @CreatedBy
+    @Column(name = "created_by", updatable = false)
+    private Long createdBy;
+
     @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     private OffsetDateTime updatedAt;
+
+    @LastModifiedBy
+    @Column(name = "updated_by")
+    private Long updatedBy;
 
     @OneToMany(mappedBy = "stocktakeHeader", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default

--- a/backend/src/main/java/com/wms/inventory/entity/StocktakeLine.java
+++ b/backend/src/main/java/com/wms/inventory/entity/StocktakeLine.java
@@ -15,7 +15,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -87,7 +89,15 @@ public class StocktakeLine {
     @Column(name = "created_at", nullable = false, updatable = false)
     private OffsetDateTime createdAt;
 
+    @CreatedBy
+    @Column(name = "created_by", updatable = false)
+    private Long createdBy;
+
     @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     private OffsetDateTime updatedAt;
+
+    @LastModifiedBy
+    @Column(name = "updated_by")
+    private Long updatedBy;
 }

--- a/backend/src/main/resources/db/migration/V20__add_audit_columns_to_stocktake_tables.sql
+++ b/backend/src/main/resources/db/migration/V20__add_audit_columns_to_stocktake_tables.sql
@@ -1,0 +1,7 @@
+-- stocktake_headers に created_by / updated_by 監査カラムを追加（RULE-DB-005 準拠）
+ALTER TABLE stocktake_headers ADD COLUMN created_by BIGINT NULL;
+ALTER TABLE stocktake_headers ADD COLUMN updated_by BIGINT NULL;
+
+-- stocktake_lines に created_by / updated_by 監査カラムを追加（RULE-DB-005 準拠）
+ALTER TABLE stocktake_lines ADD COLUMN created_by BIGINT NULL;
+ALTER TABLE stocktake_lines ADD COLUMN updated_by BIGINT NULL;


### PR DESCRIPTION
Closes #307

## Summary
- Flywayマイグレーション（V20）で `stocktake_headers` / `stocktake_lines` に `created_by`, `updated_by` カラムを追加
- `StocktakeHeader` / `StocktakeLine` エンティティに `@CreatedBy`, `@LastModifiedBy` フィールドを追加
- 既存の `AuditingEntityListener` により自動設定される（`BaseEntity` と同じパターン）

## 変更内容
- `V20__add_audit_columns_to_stocktake_tables.sql`: 4カラム追加（nullable、既存データへの影響なし）
- `StocktakeHeader.java`: `createdBy`, `updatedBy` フィールド追加
- `StocktakeLine.java`: `createdBy`, `updatedBy` フィールド追加

## Test coverage

### Backend (JaCoCo)
| 指標 | 値 |
|------|-----|
| C0（LINE） | 変更なし（エンティティフィールド追加のみ） |
| C1（BRANCH） | 変更なし |

## Test plan
- [x] inventoryモジュールの全テスト通過
- [x] Checkstyle / SpotBugs 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)