### PR TITLE
V20で漏れたstocktake監査カラムのFK制約を追加

### DIFF
--- a/backend/src/main/resources/db/migration/V21__add_fk_to_stocktake_audit_columns.sql
+++ b/backend/src/main/resources/db/migration/V21__add_fk_to_stocktake_audit_columns.sql
@@ -1,0 +1,6 @@
+-- V20で追加した created_by / updated_by にFK制約を追加（V20マージ時に漏れた修正）
+ALTER TABLE stocktake_headers ADD CONSTRAINT fk_stocktake_headers_created_by FOREIGN KEY (created_by) REFERENCES users(id);
+ALTER TABLE stocktake_headers ADD CONSTRAINT fk_stocktake_headers_updated_by FOREIGN KEY (updated_by) REFERENCES users(id);
+
+ALTER TABLE stocktake_lines ADD CONSTRAINT fk_stocktake_lines_created_by FOREIGN KEY (created_by) REFERENCES users(id);
+ALTER TABLE stocktake_lines ADD CONSTRAINT fk_stocktake_lines_updated_by FOREIGN KEY (updated_by) REFERENCES users(id);


### PR DESCRIPTION
## Summary
- PR #323 のレビューでFK制約欠落を指摘されたが、修正をpushした時点でPRが既にマージ済みだったため、修正がmainに入らなかった
- V21マイグレーションで `created_by` / `updated_by` に `REFERENCES users(id)` のFK制約を追加

## 変更ファイル
- `V21__add_fk_to_stocktake_audit_columns.sql`

🤖 Generated with [Claude Code](https://claude.com/claude-code)