### PR TITLE
fix: static_website非推奨警告を解消

### DIFF
--- a/infra/modules/storage/main.tf
+++ b/infra/modules/storage/main.tf
@@ -7,11 +7,6 @@ resource "azurerm_storage_account" "main" {
   account_kind             = "StorageV2"
   min_tls_version          = "TLS1_2"
 
-  static_website {
-    index_document     = "index.html"
-    error_404_document = "index.html"
-  }
-
   blob_properties {
     cors_rule {
       allowed_headers    = ["*"]
@@ -23,6 +18,12 @@ resource "azurerm_storage_account" "main" {
   }
 
   tags = var.common_tags
+}
+
+resource "azurerm_storage_account_static_website" "main" {
+  storage_account_id = azurerm_storage_account.main.id
+  index_document     = "index.html"
+  error_404_document = "index.html"
 }
 
 resource "azurerm_storage_container" "iffiles" {


### PR DESCRIPTION
## Summary
- `azurerm_storage_account` 内のインライン `static_website` ブロックを、別リソース `azurerm_storage_account_static_website` に分離
- AzureRM provider v5.0 で削除予定の非推奨警告を解消

## Test plan
- [x] `terraform plan` で Warning が消えることを確認済み
- [ ] `terraform apply` で静的サイトホスティングが正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)