### PR TITLE
feat: inventory_movementsに訂正履歴取得用複合インデックス追加

### DIFF
--- a/backend/src/main/resources/db/migration/V22__add_correction_history_index.sql
+++ b/backend/src/main/resources/db/migration/V22__add_correction_history_index.sql
@@ -1,0 +1,5 @@
+-- 訂正履歴取得クエリ用の複合インデックス
+-- GET /api/v1/inventory/correction-history で使用
+-- 条件: (warehouse_id, location_id, product_id, unit_type, movement_type) + ORDER BY executed_at DESC LIMIT 5
+CREATE INDEX idx_inventory_movements_correction_history
+    ON inventory_movements (warehouse_id, location_id, product_id, unit_type, movement_type, executed_at DESC);


### PR DESCRIPTION
Closes #303

## Summary
- `inventory_movements` テーブルに訂正履歴取得クエリ（`GET /api/v1/inventory/correction-history`）用の複合インデックスを追加
- 条件カラム: `(warehouse_id, location_id, product_id, unit_type, movement_type, executed_at DESC)`
- Flywayマイグレーション V22 として追加

## Test plan
- [x] DDLのみの変更のためテスト変更不要
- [x] Flywayマイグレーション構文確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)