### PR TITLE
VALIDATION_ERROR置換に伴う設計書のエラーコード更新

### DIFF
--- a/docs/architecture-design/error-codes.md
+++ b/docs/architecture-design/error-codes.md
@@ -140,12 +140,23 @@
 | `OUTBOUND_PARTNER_REQUIRED` | 422 | 出荷先IDが必要 |
 | `OUTBOUND_PRODUCT_SHIPMENT_STOPPED` | 422 | 商品が出荷停止 |
 | `PICKING_NOT_FOUND` | 404 | ピッキング指示が見つからない |
+| `PICKING_LINE_NOT_FOUND` | 422 | 指定されたlineIdが当該ピッキング指示に存在しない |
+| `PICKING_QTY_EXCEEDED` | 422 | ピッキング完了数量がピッキング予定数量を超えている |
+| `PICKING_NO_ALLOCATION_CANDIDATES` | 422 | ピッキング対象の引当明細が存在しない |
 | `UNPACK_NOT_COMPLETED` | 422 | ばらし指示未完了 |
 | `ALLOCATION_INSUFFICIENT` | 422 | 引当不足 |
 
 ---
 
-### 3.9 バッチ処理 (batch)
+### 3.9 帳票 (report)
+
+| エラーコード | HTTPステータス | 説明 |
+|---|---|---|
+| `REPORT_PARAMETER_REQUIRED` | 422 | 必須パラメータの組み合わせが不足 |
+
+---
+
+### 3.10 バッチ処理 (batch)
 
 | エラーコード | HTTPステータス | 説明 |
 |---|---|---|
@@ -154,7 +165,7 @@
 
 ---
 
-### 3.10 システムパラメータ (system-parameters)
+### 3.11 システムパラメータ (system-parameters)
 
 | エラーコード | HTTPステータス | 説明 |
 |---|---|---|
@@ -162,7 +173,7 @@
 
 ---
 
-### 3.11 在庫引当 (allocation)
+### 3.12 在庫引当 (allocation)
 
 | エラーコード | HTTPステータス | 説明 |
 |---|---|---|
@@ -173,7 +184,7 @@
 
 ---
 
-### 3.12 返品管理 (returns)
+### 3.13 返品管理 (returns)
 
 | エラーコード | HTTPステータス | 説明 |
 |---|---|---|

--- a/docs/functional-design/API-08-outbound.md
+++ b/docs/functional-design/API-08-outbound.md
@@ -1043,9 +1043,10 @@ flowchart TD
 
 | HTTPステータス | エラーコード | 説明 |
 |-------------|------------|------|
-| `400` | `VALIDATION_ERROR` | `qtyPicked` が `qty_to_pick` を超えている等 |
 | `404` | `PICKING_NOT_FOUND` | 指定IDのピッキング指示が存在しない |
 | `409` | `OUTBOUND_INVALID_STATUS` | 既に `COMPLETED` 状態のピッキング指示 |
+| `422` | `PICKING_LINE_NOT_FOUND` | 指定された `lineId` が当該ピッキング指示に存在しない |
+| `422` | `PICKING_QTY_EXCEEDED` | `qtyPicked` が `qty_to_pick` を超えている |
 
 ---
 
@@ -1058,7 +1059,8 @@ flowchart TD
     FIND -->|OK| CHECK_STATUS{status == COMPLETED?}
     CHECK_STATUS -->|Yes| ERR_STATUS[409 OUTBOUND_INVALID_STATUS]
     CHECK_STATUS -->|No| VALIDATE_LINES[リクエストの lines バリデーション\n当該指示に属するlineIdか確認\nqtyPicked <= qty_to_pick]
-    VALIDATE_LINES -->|NG| ERR_VAL[400 VALIDATION_ERROR]
+    VALIDATE_LINES -->|lineId不正| ERR_LINE[422 PICKING_LINE_NOT_FOUND]
+    VALIDATE_LINES -->|数量超過| ERR_QTY[422 PICKING_QTY_EXCEEDED]
     VALIDATE_LINES -->|OK| UPDATE_PIL[picking_instruction_lines 更新\nqty_picked = リクエスト値\nline_status = COMPLETED]
     UPDATE_PIL --> CHECK_FIRST{初めての完了登録?}
     CHECK_FIRST -->|Yes| SET_IN_PROGRESS[picking_instructions.status\n= IN_PROGRESS]
@@ -1076,8 +1078,8 @@ flowchart TD
 
 | # | ルール | エラーコード |
 |---|--------|------------|
-| 1 | リクエストの `lineId` は当該ピッキング指示に属する明細IDでなければならない | `VALIDATION_ERROR` |
-| 2 | `qtyPicked` は `qty_to_pick` を超えることはできない | `VALIDATION_ERROR` |
+| 1 | リクエストの `lineId` は当該ピッキング指示に属する明細IDでなければならない | `PICKING_LINE_NOT_FOUND` |
+| 2 | `qtyPicked` は `qty_to_pick` を超えることはできない | `PICKING_QTY_EXCEEDED` |
 | 3 | 最初の明細チェックが記録された時点で `picking_instructions.status` を `IN_PROGRESS` に更新する | — |
 | 4 | 全明細が `COMPLETED` になった時点で `picking_instructions.status` を `COMPLETED` に更新し、`completed_at`、`completed_by` を記録する | — |
 | 5 | 全明細完了時に、当該ピッキング指示に紐づく全ての `outbound_slips.status` を `PICKING_COMPLETED` に更新する | — |
@@ -1370,6 +1372,9 @@ flowchart TD
 | `PLANNED_DATE_TOO_EARLY` | 422 | 出荷予定日が現在営業日より前 | OUT-002 |
 | `DUPLICATE_PRODUCT_IN_LINES` | 409 | 同一伝票内に同じ商品が複数指定されている | OUT-002 |
 | `PICKING_NOT_FOUND` | 404 | ピッキング指示が見つからない | OUT-013, OUT-014 |
+| `PICKING_LINE_NOT_FOUND` | 422 | 指定された `lineId` が当該ピッキング指示に存在しない | OUT-014 |
+| `PICKING_QTY_EXCEEDED` | 422 | ピッキング完了数量がピッキング予定数量を超えている | OUT-014 |
+| `PICKING_NO_ALLOCATION_CANDIDATES` | 422 | ピッキング対象の引当明細が存在しない | OUT-012 |
 | `UNPACK_NOT_COMPLETED` | 409 | 未完了のばらし指示が存在するためピッキング指示作成不可 | OUT-012 |
 | `ALLOCATION_INSUFFICIENT` | 422 | 在庫引当に必要な在庫が不足 | API-ALL-002（引当実行） |
 | `INVENTORY_INSUFFICIENT` | 422 | 出荷完了時の在庫減算で在庫不足 | OUT-022 |

--- a/docs/functional-design/API-10-report.md
+++ b/docs/functional-design/API-10-report.md
@@ -917,7 +917,7 @@ flowchart TD
 ```mermaid
 flowchart TD
     START([開始]) --> VALIDATE{stocktakeId または\nbuildingId のどちらか指定?}
-    VALIDATE -->|両方なし| ERR_VAL[400 VALIDATION_ERROR]
+    VALIDATE -->|両方なし| ERR_VAL[422 REPORT_PARAMETER_REQUIRED]
     VALIDATE -->|stocktakeId 指定| FIND_STK{棚卸 存在確認}
     VALIDATE -->|buildingId 指定| FIND_BLD{棟 存在確認}
 
@@ -937,7 +937,7 @@ flowchart TD
 
 | # | ルール | エラーコード |
 |---|--------|------------|
-| 1 | `stocktakeId` と `buildingId` の両方が未指定の場合は 400 を返す | `VALIDATION_ERROR` |
+| 1 | `stocktakeId` と `buildingId` の両方が未指定の場合は 422 を返す | `REPORT_PARAMETER_REQUIRED` |
 | 2 | `stocktakeId` 指定時に棚卸が存在しない場合は 404 を返す | `STOCKTAKE_NOT_FOUND` |
 | 3 | `buildingId` 指定時に棟が存在しない場合は 404 を返す | `BUILDING_NOT_FOUND` |
 | 4 | 結果はロケーションコード昇順でソートして返す（現場でのピッキング動線に合わせる） | — |


### PR DESCRIPTION
Closes #335

## Summary
- API-OUT-014（ピッキング完了登録）: `VALIDATION_ERROR` → `PICKING_LINE_NOT_FOUND`(422), `PICKING_QTY_EXCEEDED`(422) に置換
- API-RPT-010（棚卸リスト）: `VALIDATION_ERROR` → `REPORT_PARAMETER_REQUIRED`(422) に置換
- error-codes.md: `PICKING_LINE_NOT_FOUND`, `PICKING_QTY_EXCEEDED`, `PICKING_NO_ALLOCATION_CANDIDATES`, `REPORT_PARAMETER_REQUIRED` を追加（帳票セクション新設）

## 変更ファイル
- `docs/functional-design/API-08-outbound.md` — エラーレスポンス表・フローチャート・ビジネスルール表・エラーコード一覧表を更新
- `docs/functional-design/API-10-report.md` — フローチャート・ビジネスルール表を更新
- `docs/architecture-design/error-codes.md` — 4エラーコード追加、セクション3.9（帳票）新設

## Test plan
- [x] `node docs/scripts/build-docs.js --validate` 全パス
- [x] Java実装コードとの整合性確認済み（BusinessRuleViolationException → 422）
- [x] HTMLポータル再生成済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)