### PR TITLE
ReturnsReportRepositoryのEntity型をReturnSlipに修正

### DIFF
--- a/backend/src/main/java/com/wms/report/repository/ReturnsReportRepository.java
+++ b/backend/src/main/java/com/wms/report/repository/ReturnsReportRepository.java
@@ -1,7 +1,7 @@
 package com.wms.report.repository;
 
-import com.wms.report.entity.BatchExecutionLog;
 import com.wms.report.repository.projection.ReturnsReportRow;
+import com.wms.returns.entity.ReturnSlip;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,7 +13,7 @@ import java.util.List;
  * RPT-18: 返品レポート用リポジトリ。
  * return_slips テーブルから返品明細を取得する（商品・取引先情報は非正規化カラム）。
  */
-public interface ReturnsReportRepository extends JpaRepository<BatchExecutionLog, Long> {
+public interface ReturnsReportRepository extends JpaRepository<ReturnSlip, Long> {
 
     /**
      * 返品レポートデータ取得。


### PR DESCRIPTION
Closes #344

## Summary
- `ReturnsReportRepository` の `JpaRepository` 型パラメータを `BatchExecutionLog` から `ReturnSlip` に修正
- 全10個のレポートRepositoryで正しいEntity指定に統一

## Test coverage

### Backend (JaCoCo)
| 指標 | 値 |
|------|-----|
| C0（LINE） | 100% |
| C1（BRANCH） | 100% |

## Test plan
- [x] 全テストグリーン（既存テストで動作確認）
- [x] `ReturnsReportService` のカバレッジ維持（C0/C1 100%）

🤖 Generated with [Claude Code](https://claude.com/claude-code)