### PR TITLE
fix: formatDateのUTC変換ズレ修正

### DIFF
--- a/frontend/src/__tests__/composables/inventory/useStocktakeForm.test.ts
+++ b/frontend/src/__tests__/composables/inventory/useStocktakeForm.test.ts
@@ -3,7 +3,7 @@ import apiClient from '@/api/client'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { withSetup, mockAxiosResponse } from '../../helpers'
 import { useStocktakeForm } from '@/composables/inventory/useStocktakeForm'
-import { toDateString } from '@/utils/dateFormat'
+import { formatLocalDate } from '@/utils/dateFormat'
 import { useWarehouseStore } from '@/stores/warehouse'
 import { mockRouter } from '../../setup'
 
@@ -120,7 +120,7 @@ describe('useStocktakeForm', () => {
 
     result.selectedBuildingId.value = 1
     // Set date to today to pass validation
-    result.stocktakeDate.value = toDateString(new Date())
+    result.stocktakeDate.value = formatLocalDate(new Date())
     result.targetLocationCount.value = 5
 
     await result.submitStart()

--- a/frontend/src/__tests__/utils/dateFormat.test.ts
+++ b/frontend/src/__tests__/utils/dateFormat.test.ts
@@ -1,26 +1,26 @@
 import { describe, it, expect } from 'vitest'
-import { toDateString } from '@/utils/dateFormat'
+import { formatLocalDate } from '@/utils/dateFormat'
 
-describe('toDateString', () => {
+describe('formatLocalDate', () => {
   it('YYYY-MM-DD 形式の文字列を返す', () => {
     const d = new Date(2026, 0, 15) // 2026-01-15 ローカル
-    expect(toDateString(d)).toBe('2026-01-15')
+    expect(formatLocalDate(d)).toBe('2026-01-15')
   })
 
   it('月・日が1桁の場合ゼロ埋めされる', () => {
     const d = new Date(2026, 2, 5) // 2026-03-05 ローカル
-    expect(toDateString(d)).toBe('2026-03-05')
+    expect(formatLocalDate(d)).toBe('2026-03-05')
   })
 
   it('年末の日付を正しくフォーマットする', () => {
     const d = new Date(2025, 11, 31) // 2025-12-31 ローカル
-    expect(toDateString(d)).toBe('2025-12-31')
+    expect(formatLocalDate(d)).toBe('2025-12-31')
   })
 
   it('ローカルタイムゾーンの日付を返す（UTC変換しない）', () => {
-    // JST 2026-04-01 00:30 = UTC 2025-03-31 15:30
+    // JST 2026-04-01 00:30 = UTC 2026-03-31 15:30
     // toISOString().slice(0,10) だと '2026-03-31' になるケース
     const d = new Date(2026, 3, 1, 0, 30, 0) // ローカル 4月1日 0:30
-    expect(toDateString(d)).toBe('2026-04-01')
+    expect(formatLocalDate(d)).toBe('2026-04-01')
   })
 })

--- a/frontend/src/composables/batch/useBatchHistory.ts
+++ b/frontend/src/composables/batch/useBatchHistory.ts
@@ -5,7 +5,7 @@ import axios from 'axios'
 import apiClient from '@/api/client'
 import { toApiError } from '@/utils/apiError'
 import { downloadReport } from '@/utils/reportDownload'
-import { toDateString } from '@/utils/dateFormat'
+import { formatLocalDate } from '@/utils/dateFormat'
 import type { BatchExecutionDetail } from '@/api/generated/models/batch-execution-detail'
 import type { BatchExecutionPageResponse } from '@/api/generated/models/batch-execution-page-response'
 import type { BatchExecutionStatus } from '@/api/generated/models/batch-execution-status'
@@ -26,8 +26,8 @@ export function useBatchHistory() {
   defaultFrom.setMonth(defaultFrom.getMonth() - 1)
 
   const searchForm = reactive({
-    executedDateFrom: toDateString(defaultFrom) as string | null,
-    executedDateTo: toDateString(today) as string | null,
+    executedDateFrom: formatLocalDate(defaultFrom) as string | null,
+    executedDateTo: formatLocalDate(today) as string | null,
     targetBusinessDate: null as string | null,
     status: null as BatchExecutionStatus | null,
   })
@@ -114,8 +114,8 @@ export function useBatchHistory() {
     const now = new Date()
     const from = new Date(now)
     from.setMonth(from.getMonth() - 1)
-    searchForm.executedDateFrom = toDateString(from)
-    searchForm.executedDateTo = toDateString(now)
+    searchForm.executedDateFrom = formatLocalDate(from)
+    searchForm.executedDateTo = formatLocalDate(now)
     searchForm.targetBusinessDate = null
     searchForm.status = null
     page.value = 1
@@ -175,7 +175,7 @@ export function useBatchHistory() {
   }
 
   function isDateDisabled(date: Date): boolean {
-    const dateStr = toDateString(date)
+    const dateStr = formatLocalDate(date)
     return !processedDates.value.includes(dateStr)
   }
 

--- a/frontend/src/composables/inbound/useInboundSlipList.ts
+++ b/frontend/src/composables/inbound/useInboundSlipList.ts
@@ -5,7 +5,7 @@ import axios from 'axios'
 import apiClient from '@/api/client'
 import { toApiError } from '@/utils/apiError'
 import { downloadReport } from '@/utils/reportDownload'
-import { toDateString } from '@/utils/dateFormat'
+import { formatLocalDate } from '@/utils/dateFormat'
 import { useWarehouseStore } from '@/stores/warehouse'
 import { useAuthStore } from '@/stores/auth'
 import type { InboundSlipSummary } from '@/api/generated/models/inbound-slip-summary'
@@ -35,8 +35,8 @@ export function useInboundSlipList() {
 
   const searchForm = reactive({
     slipNumber: '',
-    plannedDateFrom: toDateString(defaultFrom) as string | null,
-    plannedDateTo: toDateString(defaultTo) as string | null,
+    plannedDateFrom: formatLocalDate(defaultFrom) as string | null,
+    plannedDateTo: formatLocalDate(defaultTo) as string | null,
     partnerId: null as number | null,
     status: null as InboundSlipStatus | null,
   })
@@ -152,8 +152,8 @@ export function useInboundSlipList() {
     const to = new Date(now)
     to.setDate(to.getDate() + 30)
     searchForm.slipNumber = ''
-    searchForm.plannedDateFrom = toDateString(from)
-    searchForm.plannedDateTo = toDateString(to)
+    searchForm.plannedDateFrom = formatLocalDate(from)
+    searchForm.plannedDateTo = formatLocalDate(to)
     searchForm.partnerId = null
     searchForm.status = null
     page.value = 1
@@ -191,7 +191,7 @@ export function useInboundSlipList() {
         path: '/reports/inbound-plan',
         params,
         format: 'pdf',
-        filenameBase: 'inbound_plan_' + toDateString(new Date()).replace(/-/g, ''),
+        filenameBase: 'inbound_plan_' + formatLocalDate(new Date()).replace(/-/g, ''),
       })
     } catch {
       ElMessage.error(t('inbound.slip.reportDownloadError'))
@@ -211,7 +211,7 @@ export function useInboundSlipList() {
           warehouseId: warehouseStore.selectedWarehouseId,
         },
         format: 'pdf',
-        filenameBase: 'unreceived_realtime_' + toDateString(new Date()).replace(/-/g, ''),
+        filenameBase: 'unreceived_realtime_' + formatLocalDate(new Date()).replace(/-/g, ''),
       })
     } catch {
       ElMessage.error(t('inbound.slip.reportDownloadError'))

--- a/frontend/src/composables/interface/useInterfaceHistory.ts
+++ b/frontend/src/composables/interface/useInterfaceHistory.ts
@@ -4,7 +4,7 @@ import { ElMessage } from 'element-plus'
 import axios from 'axios'
 import apiClient from '@/api/client'
 import { toApiError } from '@/utils/apiError'
-import { toDateString } from '@/utils/dateFormat'
+import { formatLocalDate } from '@/utils/dateFormat'
 import type { IfExecutionItem } from '@/api/generated/models/if-execution-item'
 import type { IfExecutionPageResponse } from '@/api/generated/models/if-execution-page-response'
 
@@ -25,8 +25,8 @@ export function useInterfaceHistory() {
 
   const searchForm = reactive({
     ifType: null as string | null,
-    dateFrom: toDateString(defaultFrom) as string | null,
-    dateTo: toDateString(today) as string | null,
+    dateFrom: formatLocalDate(defaultFrom) as string | null,
+    dateTo: formatLocalDate(today) as string | null,
     status: null as string | null,
     fileName: '',
   })
@@ -90,8 +90,8 @@ export function useInterfaceHistory() {
     const from = new Date(now)
     from.setMonth(from.getMonth() - 1)
     searchForm.ifType = null
-    searchForm.dateFrom = toDateString(from)
-    searchForm.dateTo = toDateString(now)
+    searchForm.dateFrom = formatLocalDate(from)
+    searchForm.dateTo = formatLocalDate(now)
     searchForm.status = null
     searchForm.fileName = ''
     page.value = 1

--- a/frontend/src/composables/inventory/useStocktakeForm.ts
+++ b/frontend/src/composables/inventory/useStocktakeForm.ts
@@ -4,7 +4,7 @@ import { useRouter } from 'vue-router'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import apiClient from '@/api/client'
 import { toApiError } from '@/utils/apiError'
-import { toDateString } from '@/utils/dateFormat'
+import { formatLocalDate } from '@/utils/dateFormat'
 import { useWarehouseStore } from '@/stores/warehouse'
 
 interface BuildingOption {
@@ -33,7 +33,7 @@ export function useStocktakeForm() {
   // フォーム
   const selectedBuildingId = ref<number | null>(null)
   const selectedAreaId = ref<number | null>(null)
-  const stocktakeDate = ref(toDateString(new Date()))
+  const stocktakeDate = ref(formatLocalDate(new Date()))
   const note = ref('')
 
   // マスタオプション
@@ -143,7 +143,7 @@ export function useStocktakeForm() {
       return
     }
     // 実施日は当日以降（フロントエンドバリデーション）
-    const today = toDateString(new Date())
+    const today = formatLocalDate(new Date())
     if (stocktakeDate.value < today) {
       ElMessage.error(t('inventory.stocktakeDateRequired'))
       return

--- a/frontend/src/composables/inventory/useStocktakeList.ts
+++ b/frontend/src/composables/inventory/useStocktakeList.ts
@@ -5,7 +5,7 @@ import { ElMessage } from 'element-plus'
 import axios from 'axios'
 import apiClient from '@/api/client'
 import { toApiError } from '@/utils/apiError'
-import { toDateString } from '@/utils/dateFormat'
+import { formatLocalDate } from '@/utils/dateFormat'
 import { useWarehouseStore } from '@/stores/warehouse'
 import { useAuthStore } from '@/stores/auth'
 import type { StocktakeSummary } from '@/api/generated/models/stocktake-summary'
@@ -65,8 +65,8 @@ export function useStocktakeList() {
   const searchForm = reactive({
     stocktakeNumber: '' as string,
     buildingId: null as number | null,
-    dateFrom: toDateString(monthStart) as string | null,
-    dateTo: toDateString(now) as string | null,
+    dateFrom: formatLocalDate(monthStart) as string | null,
+    dateTo: formatLocalDate(now) as string | null,
     status: null as string | null,
   })
 
@@ -147,8 +147,8 @@ export function useStocktakeList() {
     const resetMonthStart = new Date(resetNow.getFullYear(), resetNow.getMonth(), 1)
     searchForm.stocktakeNumber = ''
     searchForm.buildingId = null
-    searchForm.dateFrom = toDateString(resetMonthStart)
-    searchForm.dateTo = toDateString(resetNow)
+    searchForm.dateFrom = formatLocalDate(resetMonthStart)
+    searchForm.dateTo = formatLocalDate(resetNow)
     searchForm.status = null
     page.value = 1
     fetchList()

--- a/frontend/src/composables/outbound/useOutboundSlipList.ts
+++ b/frontend/src/composables/outbound/useOutboundSlipList.ts
@@ -4,7 +4,7 @@ import { ElMessage, ElMessageBox } from 'element-plus'
 import axios from 'axios'
 import apiClient from '@/api/client'
 import { toApiError } from '@/utils/apiError'
-import { toDateString } from '@/utils/dateFormat'
+import { formatLocalDate } from '@/utils/dateFormat'
 import { useWarehouseStore } from '@/stores/warehouse'
 import { useAuthStore } from '@/stores/auth'
 import type { OutboundSlipSummary } from '@/api/generated/models/outbound-slip-summary'
@@ -35,8 +35,8 @@ export function useOutboundSlipList() {
 
   const searchForm = reactive({
     slipNumber: '',
-    plannedDateFrom: toDateString(defaultFrom) as string | null,
-    plannedDateTo: toDateString(defaultTo) as string | null,
+    plannedDateFrom: formatLocalDate(defaultFrom) as string | null,
+    plannedDateTo: formatLocalDate(defaultTo) as string | null,
     partnerId: null as number | null,
     status: null as OutboundSlipStatus | null,
   })
@@ -151,8 +151,8 @@ export function useOutboundSlipList() {
     const to = new Date(now)
     to.setDate(to.getDate() + 30)
     searchForm.slipNumber = ''
-    searchForm.plannedDateFrom = toDateString(from)
-    searchForm.plannedDateTo = toDateString(to)
+    searchForm.plannedDateFrom = formatLocalDate(from)
+    searchForm.plannedDateTo = formatLocalDate(to)
     searchForm.partnerId = null
     searchForm.status = null
     page.value = 1

--- a/frontend/src/utils/dateFormat.ts
+++ b/frontend/src/utils/dateFormat.ts
@@ -4,7 +4,10 @@
  * toISOString().slice(0,10) は UTC 変換されるため、
  * JST 深夜 0時〜9時の間に1日ずれる問題がある。
  * sv-SE ロケールは常に YYYY-MM-DD を返すため安全。
+ *
+ * 前提: ブラウザおよび full-icu の Node.js 環境で使用すること。
+ * Node.js の small-icu ビルドでは sv-SE ロケールが含まれない場合がある。
  */
-export function toDateString(d: Date): string {
+export function formatLocalDate(d: Date): string {
   return d.toLocaleDateString('sv-SE')
 }


### PR DESCRIPTION
Closes #365

## Summary
- `toISOString().slice(0,10)` によるUTC変換で、JST深夜0時〜9時に日付が1日ずれる問題を修正
- 共通ユーティリティ `toDateString()` を `utils/dateFormat.ts` に新設（`toLocaleDateString('sv-SE')` ベース）
- 全 composable のローカル `formatDate` 関数を `toDateString` に統一（7ファイル）

## 変更ファイル一覧
| ファイル | 変更内容 |
|---------|---------|
| `utils/dateFormat.ts` | **新規** 共通ユーティリティ |
| `composables/batch/useBatchHistory.ts` | ローカル formatDate → toDateString |
| `composables/interface/useInterfaceHistory.ts` | ローカル formatDate → toDateString |
| `composables/inbound/useInboundSlipList.ts` | ローカル formatDate + ファイル名生成 → toDateString |
| `composables/outbound/useOutboundSlipList.ts` | モジュールレベル formatDate → toDateString |
| `composables/inventory/useStocktakeList.ts` | ローカル formatDate → toDateString |
| `composables/inventory/useStocktakeForm.ts` | 直接 toISOString 呼び出し → toDateString |
| `__tests__/utils/dateFormat.test.ts` | **新規** toDateString のユニットテスト |
| `__tests__/composables/inventory/useStocktakeForm.test.ts` | テストコード同期 |

## Test coverage

### Frontend (v8)
| 指標 | 値 |
|------|-----|
| Stmts（dateFormat.ts） | 100% |
| Branch（dateFormat.ts） | 100% |

※ 既存 composable のカバレッジは既存テストで維持。今回の変更はimport先の差し替えのみで分岐増減なし。

## Test plan
- [x] toDateString が YYYY-MM-DD 形式を返す
- [x] 月・日のゼロ埋めが正しい
- [x] ローカルTZ日付を返す（UTC変換しない）
- [x] 全815テスト PASS
- [x] vue-tsc 型チェック PASS
- [x] ESLint PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)