### PR TITLE
test: 倉庫/棟/エリア/ロケーション結合テスト (#388)

### DIFF
--- a/backend/src/test/java/com/wms/master/controller/AreaIntegrationTest.java
+++ b/backend/src/test/java/com/wms/master/controller/AreaIntegrationTest.java
@@ -493,6 +493,39 @@ class AreaIntegrationTest extends IntegrationTestBase {
         }
 
         @Test
+        @DisplayName("WAREHOUSE_STAFFはエリア更新不可 → 403")
+        void update_asStaff_returns403() throws Exception {
+            Long areaId = createArea(testBuildingId, "S01", "スタッフ更新テスト", "AMBIENT", "STOCK");
+            HttpHeaders staffHeaders = loginAndGetHeaders(STAFF_CODE, STAFF_PASSWORD);
+            String body = """
+                    { "areaName": "スタッフ更新", "storageCondition": "AMBIENT", "version": 0 }
+                    """;
+
+            HttpEntity<String> request = new HttpEntity<>(body, staffHeaders);
+            ResponseEntity<String> response = restTemplate.exchange(
+                    BASE_URL + "/" + areaId, HttpMethod.PUT, request, String.class);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+        }
+
+        @Test
+        @DisplayName("WAREHOUSE_STAFFはエリア有効/無効切替不可 → 403")
+        void toggle_asStaff_returns403() throws Exception {
+            Long areaId = createArea(testBuildingId, "S02", "スタッフ切替テスト", "AMBIENT", "STOCK");
+            HttpHeaders staffHeaders = loginAndGetHeaders(STAFF_CODE, STAFF_PASSWORD);
+            String body = """
+                    { "isActive": false, "version": 0 }
+                    """;
+
+            HttpEntity<String> request = new HttpEntity<>(body, staffHeaders);
+            ResponseEntity<String> response = restTemplate.exchange(
+                    BASE_URL + "/" + areaId + "/toggle-active",
+                    HttpMethod.PATCH, request, String.class);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+        }
+
+        @Test
         @DisplayName("WAREHOUSE_STAFFは一覧取得可能")
         void list_asStaff_returns200() throws Exception {
             HttpHeaders staffHeaders = loginAndGetHeaders(STAFF_CODE, STAFF_PASSWORD);

--- a/backend/src/test/java/com/wms/master/controller/BuildingIntegrationTest.java
+++ b/backend/src/test/java/com/wms/master/controller/BuildingIntegrationTest.java
@@ -386,6 +386,39 @@ class BuildingIntegrationTest extends IntegrationTestBase {
         }
 
         @Test
+        @DisplayName("WAREHOUSE_STAFFは棟更新不可 → 403")
+        void update_asStaff_returns403() throws Exception {
+            Long buildingId = createBuilding(testWarehouseId, "R", "R棟");
+            HttpHeaders staffHeaders = loginAndGetHeaders(STAFF_CODE, STAFF_PASSWORD);
+            String body = """
+                    { "buildingName": "スタッフ更新", "version": 0 }
+                    """;
+
+            HttpEntity<String> request = new HttpEntity<>(body, staffHeaders);
+            ResponseEntity<String> response = restTemplate.exchange(
+                    BASE_URL + "/" + buildingId, HttpMethod.PUT, request, String.class);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+        }
+
+        @Test
+        @DisplayName("WAREHOUSE_STAFFは棟有効/無効切替不可 → 403")
+        void toggle_asStaff_returns403() throws Exception {
+            Long buildingId = createBuilding(testWarehouseId, "S", "S棟");
+            HttpHeaders staffHeaders = loginAndGetHeaders(STAFF_CODE, STAFF_PASSWORD);
+            String body = """
+                    { "isActive": false, "version": 0 }
+                    """;
+
+            HttpEntity<String> request = new HttpEntity<>(body, staffHeaders);
+            ResponseEntity<String> response = restTemplate.exchange(
+                    BASE_URL + "/" + buildingId + "/toggle-active",
+                    HttpMethod.PATCH, request, String.class);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+        }
+
+        @Test
         @DisplayName("WAREHOUSE_STAFFは一覧取得可能")
         void list_asStaff_returns200() throws Exception {
             HttpHeaders staffHeaders = loginAndGetHeaders(STAFF_CODE, STAFF_PASSWORD);

--- a/backend/src/test/java/com/wms/master/controller/FacilityHierarchyIntegrationTest.java
+++ b/backend/src/test/java/com/wms/master/controller/FacilityHierarchyIntegrationTest.java
@@ -172,15 +172,15 @@ class FacilityHierarchyIntegrationTest extends IntegrationTestBase {
     }
 
     @Test
-    @DisplayName("子を全て無効化した後なら親を無効化できる（ボトムアップ）")
-    void hierarchicalDeactivation_bottomUpSucceeds() throws Exception {
+    @DisplayName("ボトムアップ無効化: ロケーション→エリアは成功するが、棟は子エリア数で判定のため失敗する")
+    void hierarchicalDeactivation_bottomUp_areaSucceeds_buildingFails() throws Exception {
         // 階層構築
         Long warehouseId = createWarehouse("ITBU");
         Long buildingId = createBuilding(warehouseId, "A");
         Long areaId = createArea(buildingId, "A01", "STOCK");
         Long locationId = createLocation(areaId, "A-01-A01-01-01-01");
 
-        // ロケーションを無効化
+        // ロケーションを無効化 → 成功
         Integer locVersion = jdbcTemplate.queryForObject(
                 "SELECT version FROM locations WHERE id = ?", Integer.class, locationId);
         String locToggle = String.format("""
@@ -191,7 +191,7 @@ class FacilityHierarchyIntegrationTest extends IntegrationTestBase {
                 HttpMethod.PATCH, new HttpEntity<>(locToggle, adminHeaders), String.class);
         assertThat(locResp.getStatusCode()).isEqualTo(HttpStatus.OK);
 
-        // エリアを無効化（子ロケーションは無効化済み→OK）
+        // エリアを無効化（子ロケーションは無効化済み）→ 成功
         Integer areaVersion = jdbcTemplate.queryForObject(
                 "SELECT version FROM areas WHERE id = ?", Integer.class, areaId);
         String areaToggle = String.format("""
@@ -202,9 +202,7 @@ class FacilityHierarchyIntegrationTest extends IntegrationTestBase {
                 HttpMethod.PATCH, new HttpEntity<>(areaToggle, adminHeaders), String.class);
         assertThat(areaResp.getStatusCode()).isEqualTo(HttpStatus.OK);
 
-        // 棟を無効化（子エリアは存在するが…）
-        // 注: BuildingServiceは countByBuildingId > 0 で判定（有効/無効問わず）
-        // この場合、エリアが存在するため無効化は不可
+        // 棟を無効化 → 失敗（BuildingServiceは countByBuildingId > 0 で判定。有効/無効問わず）
         Integer buildingVersion = jdbcTemplate.queryForObject(
                 "SELECT version FROM buildings WHERE id = ?", Integer.class, buildingId);
         String buildingToggle = String.format("""
@@ -213,8 +211,9 @@ class FacilityHierarchyIntegrationTest extends IntegrationTestBase {
         ResponseEntity<String> buildingResp = restTemplate.exchange(
                 BUILDING_URL + "/" + buildingId + "/toggle-active",
                 HttpMethod.PATCH, new HttpEntity<>(buildingToggle, adminHeaders), String.class);
-        // 棟はエリア数で判定（有効/無効問わず）→ 422
         assertThat(buildingResp.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+        JsonNode json = parseJson(buildingResp.getBody());
+        assertThat(json.get("code").asText()).isEqualTo("CANNOT_DEACTIVATE_HAS_CHILDREN");
     }
 
     // ========================================================

--- a/backend/src/test/java/com/wms/master/controller/FacilityIntegrationTestHelper.java
+++ b/backend/src/test/java/com/wms/master/controller/FacilityIntegrationTestHelper.java
@@ -1,0 +1,88 @@
+package com.wms.master.controller;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.function.BiFunction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Shared helper methods for facility integration tests.
+ * Reduces code duplication across Warehouse/Building/Area/Location tests.
+ */
+final class FacilityIntegrationTestHelper {
+
+    static final String WAREHOUSE_URL = "/api/v1/master/warehouses";
+    static final String BUILDING_URL = "/api/v1/master/buildings";
+    static final String AREA_URL = "/api/v1/master/areas";
+    static final String LOCATION_URL = "/api/v1/master/locations";
+
+    static final String ADMIN_CODE = "admin001";
+    static final String ADMIN_PASSWORD = "Admin@1234";
+    static final String MANAGER_CODE = "wh_manager01";
+    static final String MANAGER_PASSWORD = "Manager@1234";
+    static final String STAFF_CODE = "wh_staff01";
+    static final String STAFF_PASSWORD = "Staff@1234";
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private FacilityIntegrationTestHelper() {
+    }
+
+    static Long createWarehouse(String code, String name,
+                                BiFunction<String, String, ResponseEntity<String>> postJson,
+                                HttpHeaders headers) throws Exception {
+        String body = String.format("""
+                { "warehouseCode": "%s", "warehouseName": "%s" }
+                """, code, name);
+        ResponseEntity<String> response = postJson.apply(WAREHOUSE_URL, body);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        return OBJECT_MAPPER.readTree(response.getBody()).get("id").asLong();
+    }
+
+    static Long createBuilding(Long warehouseId, String code, String name,
+                                BiFunction<String, String, ResponseEntity<String>> postJson) throws Exception {
+        String body = String.format("""
+                { "warehouseId": %d, "buildingCode": "%s", "buildingName": "%s" }
+                """, warehouseId, code, name);
+        ResponseEntity<String> response = postJson.apply(BUILDING_URL, body);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        return OBJECT_MAPPER.readTree(response.getBody()).get("id").asLong();
+    }
+
+    static Long createArea(Long buildingId, String code, String name,
+                            String storageCondition, String areaType,
+                            BiFunction<String, String, ResponseEntity<String>> postJson) throws Exception {
+        String body = String.format("""
+                {
+                    "buildingId": %d, "areaCode": "%s", "areaName": "%s",
+                    "storageCondition": "%s", "areaType": "%s"
+                }
+                """, buildingId, code, name, storageCondition, areaType);
+        ResponseEntity<String> response = postJson.apply(AREA_URL, body);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        return OBJECT_MAPPER.readTree(response.getBody()).get("id").asLong();
+    }
+
+    static Long createLocation(Long areaId, String code, String name,
+                                BiFunction<String, String, ResponseEntity<String>> postJson) throws Exception {
+        String body = name != null
+                ? String.format("""
+                { "areaId": %d, "locationCode": "%s", "locationName": "%s" }
+                """, areaId, code, name)
+                : String.format("""
+                { "areaId": %d, "locationCode": "%s" }
+                """, areaId, code);
+        ResponseEntity<String> response = postJson.apply(LOCATION_URL, body);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        return OBJECT_MAPPER.readTree(response.getBody()).get("id").asLong();
+    }
+
+    static JsonNode parseJson(String body) throws Exception {
+        return OBJECT_MAPPER.readTree(body);
+    }
+}

--- a/backend/src/test/java/com/wms/master/controller/LocationIntegrationTest.java
+++ b/backend/src/test/java/com/wms/master/controller/LocationIntegrationTest.java
@@ -495,6 +495,39 @@ class LocationIntegrationTest extends IntegrationTestBase {
         }
 
         @Test
+        @DisplayName("WAREHOUSE_STAFFはロケーション更新不可 → 403")
+        void update_asStaff_returns403() throws Exception {
+            Long locationId = createLocation(testStockAreaId, "A-01-A01-99-02-01", "スタッフ更新テスト");
+            HttpHeaders staffHeaders = loginAndGetHeaders(STAFF_CODE, STAFF_PASSWORD);
+            String body = """
+                    { "locationName": "スタッフ更新", "version": 0 }
+                    """;
+
+            HttpEntity<String> request = new HttpEntity<>(body, staffHeaders);
+            ResponseEntity<String> response = restTemplate.exchange(
+                    BASE_URL + "/" + locationId, HttpMethod.PUT, request, String.class);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+        }
+
+        @Test
+        @DisplayName("WAREHOUSE_STAFFはロケーション有効/無効切替不可 → 403")
+        void toggle_asStaff_returns403() throws Exception {
+            Long locationId = createLocation(testStockAreaId, "A-01-A01-99-03-01", "スタッフ切替テスト");
+            HttpHeaders staffHeaders = loginAndGetHeaders(STAFF_CODE, STAFF_PASSWORD);
+            String body = """
+                    { "isActive": false, "version": 0 }
+                    """;
+
+            HttpEntity<String> request = new HttpEntity<>(body, staffHeaders);
+            ResponseEntity<String> response = restTemplate.exchange(
+                    BASE_URL + "/" + locationId + "/toggle-active",
+                    HttpMethod.PATCH, request, String.class);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+        }
+
+        @Test
         @DisplayName("WAREHOUSE_STAFFは一覧取得可能")
         void list_asStaff_returns200() throws Exception {
             HttpHeaders staffHeaders = loginAndGetHeaders(STAFF_CODE, STAFF_PASSWORD);

--- a/backend/src/test/java/com/wms/master/controller/WarehouseIntegrationTest.java
+++ b/backend/src/test/java/com/wms/master/controller/WarehouseIntegrationTest.java
@@ -129,6 +129,8 @@ class WarehouseIntegrationTest extends IntegrationTestBase {
             ResponseEntity<String> response = postJson(BASE_URL, body, adminHeaders);
 
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+            JsonNode json = parseJson(response.getBody());
+            assertThat(json.has("code")).isTrue();
         }
 
         @Test
@@ -521,6 +523,39 @@ class WarehouseIntegrationTest extends IntegrationTestBase {
                     new HttpEntity<>(staffHeaders), String.class);
 
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        }
+
+        @Test
+        @DisplayName("WAREHOUSE_STAFFは更新不可 → 403")
+        void update_asStaff_returns403() throws Exception {
+            Long whId = createTestWarehouse("ITSU", "スタッフ更新テスト");
+            HttpHeaders staffHeaders = loginAndGetHeaders(STAFF_CODE, STAFF_PASSWORD);
+            String body = """
+                    { "warehouseName": "スタッフ更新", "version": 0 }
+                    """;
+
+            HttpEntity<String> request = new HttpEntity<>(body, staffHeaders);
+            ResponseEntity<String> response = restTemplate.exchange(
+                    BASE_URL + "/" + whId, HttpMethod.PUT, request, String.class);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+        }
+
+        @Test
+        @DisplayName("WAREHOUSE_STAFFは有効/無効切替不可 → 403")
+        void toggle_asStaff_returns403() throws Exception {
+            Long whId = createTestWarehouse("ITST", "スタッフ切替テスト");
+            HttpHeaders staffHeaders = loginAndGetHeaders(STAFF_CODE, STAFF_PASSWORD);
+            String body = """
+                    { "isActive": false, "version": 0 }
+                    """;
+
+            HttpEntity<String> request = new HttpEntity<>(body, staffHeaders);
+            ResponseEntity<String> response = restTemplate.exchange(
+                    BASE_URL + "/" + whId + "/toggle-active",
+                    HttpMethod.PATCH, request, String.class);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
         }
 
         @Test


### PR DESCRIPTION
Closes #388

## Summary
- 倉庫管理の階層構造（倉庫→棟→エリア→ロケーション）APIの結合テスト5ファイルを実装
- WarehouseIntegrationTest: 25テスト（CRUD、exists、all=true、toggle-active、ページネーション、アクセス制御）
- BuildingIntegrationTest: 19テスト（CRUD、親子無効化制約SC-FAC03、異なる倉庫でのコード一意性）
- AreaIntegrationTest: 22テスト（CRUD、storageCondition/areaType、親子無効化制約SC-FAC06）
- LocationIntegrationTest: 24テスト（CRUD、コード形式バリデーションSC-FAC07、エリア制限SC-FAC09、prefix検索SC-FAC13、count）
- FacilityHierarchyIntegrationTest: 3テスト（一気通貫SC-FAC12、階層無効化制約チェーン）

## Test coverage

### Backend
結合テスト（Testcontainers）のため、JaCoCoカバレッジ計測対象外。
コンパイル確認済み、既存ユニットテスト全グリーン確認済み。

## Test plan
- [x] コンパイル確認（`./gradlew compileTestJava` 成功）
- [x] 既存ユニットテスト全グリーン（`./gradlew test` 成功）
- [ ] Docker環境での `./gradlew integrationTest` 実行確認（CI/ローカルDocker環境にて）

🤖 Generated with [Claude Code](https://claude.com/claude-code)