### PR TITLE
[F#3-F#5] 本番環境変数の追加（Azure Storage, ACS, Front Door）

### DIFF
--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -33,6 +33,16 @@ cookie:
 cors:
   allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:5173}
 
+# WMS Application Properties
+wms:
+  storage:
+    account-name: ${AZURE_STORAGE_ACCOUNT_NAME:devstorageaccount}
+  acs:
+    connection-string: ${ACS_CONNECTION_STRING:}
+    sender-address: ${ACS_SENDER_ADDRESS:DoNotReply@localhost}
+  frontdoor:
+    id: ${AZURE_FRONTDOOR_ID:}
+
 # Logging
 logging:
   level:

--- a/backend/src/main/resources/application-prd.yml
+++ b/backend/src/main/resources/application-prd.yml
@@ -35,6 +35,16 @@ cookie:
 cors:
   allowed-origins: ${CORS_ALLOWED_ORIGINS}
 
+# WMS Application Properties
+wms:
+  storage:
+    account-name: ${AZURE_STORAGE_ACCOUNT_NAME}
+  acs:
+    connection-string: ${ACS_CONNECTION_STRING}
+    sender-address: ${ACS_SENDER_ADDRESS}
+  frontdoor:
+    id: ${AZURE_FRONTDOOR_ID:}
+
 # Springdoc OpenAPI (disabled in production)
 springdoc:
   api-docs:


### PR DESCRIPTION
Closes #379

## Summary
- `application-prd.yml` に未設定だった4つの環境変数プレースホルダーを追加
  - `AZURE_STORAGE_ACCOUNT_NAME` — Blob Storageアカウント名
  - `ACS_CONNECTION_STRING` — Azure Communication Services接続文字列
  - `ACS_SENDER_ADDRESS` — メール送信元アドレス
  - `AZURE_FRONTDOOR_ID` — Front Door ID（ヘッダー検証用、デフォルト空）
- `application-dev.yml` にも同4変数をdev用デフォルト値付きで追加

## 指摘元
PR #376 設計準拠レビュー F#3, F#4, F#5

## Test plan
- [x] `./gradlew compileJava` でビルド成功を確認
- [x] 環境変数名が `environment-variables.md` の定義と一致することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)