### PR TITLE
test: 帳票APIの結合テストを実装 / Add report API integration tests

### DIFF
--- a/backend/src/test/java/com/wms/report/controller/ReportInboundIntegrationTest.java
+++ b/backend/src/test/java/com/wms/report/controller/ReportInboundIntegrationTest.java
@@ -37,7 +37,6 @@ class ReportInboundIntegrationTest extends IntegrationTestBase {
     private HttpHeaders viewerHeaders;
 
     private Long warehouseId;
-    private String warehouseCode;
     private Long productAmbId;
     private Long productAmb2Id;
     private Long supplierPartnerId;
@@ -47,7 +46,6 @@ class ReportInboundIntegrationTest extends IntegrationTestBase {
     void initMasterIds() {
         warehouseId = jdbcTemplate.queryForObject(
                 "SELECT id FROM warehouses WHERE warehouse_code = 'WH001'", Long.class);
-        warehouseCode = "WH001";
         productAmbId = jdbcTemplate.queryForObject(
                 "SELECT id FROM products WHERE product_code = 'AMB-001'", Long.class);
         productAmb2Id = jdbcTemplate.queryForObject(
@@ -107,30 +105,20 @@ class ReportInboundIntegrationTest extends IntegrationTestBase {
         return slipId;
     }
 
-    private void insertUnreceivedListRecord(LocalDate batchDate, String slipNumber,
-                                            LocalDate plannedDate, int plannedQty, String currentStatus) {
+    /**
+     * unreceived_list_records は inbound_slips への FK を持つため、
+     * 親となる入荷伝票を先に投入し、その slipId を返す前提で呼び出す。
+     */
+    private void insertUnreceivedListRecord(LocalDate batchDate, Long inboundSlipId,
+                                            String slipNumber, LocalDate plannedDate,
+                                            int plannedQty, String currentStatus) {
         jdbcTemplate.update("""
                 INSERT INTO unreceived_list_records (batch_business_date, inbound_slip_id, slip_number,
                     planned_date, warehouse_code, partner_code, partner_name, product_code, product_name,
                     unit_type, planned_qty, current_status, created_at)
                 VALUES (?, ?, ?, ?, 'WH001', 'SUP001', '仕入先A', 'AMB-001', 'ミネラルウォーター',
                     'PIECE', ?, ?, now())
-                """, batchDate,
-                // dummy slipId reference - we need a real one from inbound_slips for FK
-                requireSlipIdOrInsertDummy(slipNumber, plannedDate),
-                slipNumber, plannedDate, plannedQty, currentStatus);
-    }
-
-    private Long requireSlipIdOrInsertDummy(String slipNumber, LocalDate plannedDate) {
-        Long existing = jdbcTemplate.query(
-                "SELECT id FROM inbound_slips WHERE slip_number = ?",
-                rs -> rs.next() ? rs.getLong(1) : null, slipNumber);
-        if (existing != null) {
-            return existing;
-        }
-        return insertInboundSlip(slipNumber, plannedDate, "PLANNED",
-                productAmbId, "AMB-001", "ミネラルウォーター",
-                10, null, null, "PENDING");
+                """, batchDate, inboundSlipId, slipNumber, plannedDate, plannedQty, currentStatus);
     }
 
     private void assertPdfResponse(ResponseEntity<byte[]> response) {
@@ -147,6 +135,32 @@ class ReportInboundIntegrationTest extends IntegrationTestBase {
         assertThat(body.length).isGreaterThan(4);
         // %PDF magic bytes
         assertThat(new String(body, 0, 4)).isEqualTo("%PDF");
+    }
+
+    /** CSV: 200 + Content-Type text/csv + UTF-8 BOM (0xEF 0xBB 0xBF) を検証。 */
+    private void assertCsvResponse(ResponseEntity<byte[]> response) {
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getHeaders().getContentType())
+                .isNotNull()
+                .satisfies(ct -> assertThat(ct.toString()).contains("text/csv"));
+        assertThat(response.getHeaders().getFirst("Content-Disposition"))
+                .isNotNull()
+                .contains("attachment")
+                .contains(".csv");
+        byte[] body = response.getBody();
+        assertThat(body).isNotNull();
+        assertThat(body.length).isGreaterThanOrEqualTo(3);
+        // UTF-8 BOM
+        assertThat(body[0]).isEqualTo((byte) 0xEF);
+        assertThat(body[1]).isEqualTo((byte) 0xBB);
+        assertThat(body[2]).isEqualTo((byte) 0xBF);
+    }
+
+    /** Spring Security フィルタは Controller より前に走るため、伝票投入なしでも 401 を返す。 */
+    private HttpHeaders unauthHeaders() {
+        HttpHeaders h = new HttpHeaders();
+        h.setAccept(java.util.List.of(MediaType.APPLICATION_JSON));
+        return h;
     }
 
     // ========================================================
@@ -223,11 +237,21 @@ class ReportInboundIntegrationTest extends IntegrationTestBase {
         @Test
         @DisplayName("権限: 未認証で401")
         void getInboundInspection_unauthenticated_returns401() {
-            HttpHeaders unauth = new HttpHeaders();
-            unauth.setAccept(java.util.List.of(MediaType.APPLICATION_JSON));
             ResponseEntity<String> response = get(
-                    "/api/v1/reports/inbound-inspection?slipId=1&format=json", unauth);
+                    "/api/v1/reports/inbound-inspection?slipId=1&format=json", unauthHeaders());
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        }
+
+        @Test
+        @DisplayName("正常系: CSV形式で200 + UTF-8 BOM")
+        void getInboundInspection_csv_returnsCsv() {
+            Long slipId = insertInboundSlip("INB-RPT01-CSV", LocalDate.of(2026, 3, 20), "STORED",
+                    productAmbId, "AMB-001", "ミネラルウォーター", 10, 10,
+                    "2026-03-20T10:00:00+09:00", "STORED");
+            ResponseEntity<byte[]> response = getBytes(
+                    "/api/v1/reports/inbound-inspection?slipId=" + slipId + "&format=csv",
+                    adminHeaders);
+            assertCsvResponse(response);
         }
     }
 
@@ -327,6 +351,26 @@ class ReportInboundIntegrationTest extends IntegrationTestBase {
                     viewerHeaders);
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         }
+
+        @Test
+        @DisplayName("権限: 未認証で401")
+        void getInboundPlan_unauthenticated_returns401() {
+            ResponseEntity<String> response = get(
+                    "/api/v1/reports/inbound-plan?warehouseId=" + warehouseId + "&format=json",
+                    unauthHeaders());
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        }
+
+        @Test
+        @DisplayName("正常系: CSV形式で200 + UTF-8 BOM")
+        void getInboundPlan_csv_returnsCsv() {
+            insertInboundSlip("INB-RPT03-CSV", LocalDate.of(2026, 3, 20), "PLANNED",
+                    productAmbId, "AMB-001", "ミネラルウォーター", 10, null, null, "PENDING");
+            ResponseEntity<byte[]> response = getBytes(
+                    "/api/v1/reports/inbound-plan?warehouseId=" + warehouseId + "&format=csv",
+                    adminHeaders);
+            assertCsvResponse(response);
+        }
     }
 
     // ========================================================
@@ -408,6 +452,29 @@ class ReportInboundIntegrationTest extends IntegrationTestBase {
                     adminHeaders);
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
         }
+
+        @Test
+        @DisplayName("権限: VIEWERでも閲覧可能 / 未認証で401")
+        void getInboundResult_authChecks() {
+            assertThat(get(
+                    "/api/v1/reports/inbound-result?warehouseId=" + warehouseId + "&format=json",
+                    viewerHeaders).getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(get(
+                    "/api/v1/reports/inbound-result?warehouseId=" + warehouseId + "&format=json",
+                    unauthHeaders()).getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        }
+
+        @Test
+        @DisplayName("正常系: CSV形式で200 + UTF-8 BOM")
+        void getInboundResult_csv_returnsCsv() {
+            insertInboundSlip("INB-RPT04-CSV", LocalDate.of(2026, 3, 20), "STORED",
+                    productAmbId, "AMB-001", "ミネラルウォーター", 10, 10,
+                    "2026-03-20T10:00:00+09:00", "STORED");
+            ResponseEntity<byte[]> response = getBytes(
+                    "/api/v1/reports/inbound-result?warehouseId=" + warehouseId + "&format=csv",
+                    adminHeaders);
+            assertCsvResponse(response);
+        }
     }
 
     // ========================================================
@@ -472,6 +539,27 @@ class ReportInboundIntegrationTest extends IntegrationTestBase {
                     adminHeaders);
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
         }
+
+        @Test
+        @DisplayName("権限: VIEWERでも閲覧可能 / 未認証で401")
+        void getUnreceivedRealtime_authChecks() {
+            String url = "/api/v1/reports/unreceived-realtime?warehouseId=" + warehouseId
+                    + "&asOfDate=2026-03-20&format=json";
+            assertThat(get(url, viewerHeaders).getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(get(url, unauthHeaders()).getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        }
+
+        @Test
+        @DisplayName("正常系: CSV形式で200 + UTF-8 BOM")
+        void getUnreceivedRealtime_csv_returnsCsv() {
+            insertInboundSlip("INB-RPT05-CSV", LocalDate.of(2026, 3, 19), "PLANNED",
+                    productAmbId, "AMB-001", "ミネラルウォーター", 10, null, null, "PENDING");
+            ResponseEntity<byte[]> response = getBytes(
+                    "/api/v1/reports/unreceived-realtime?warehouseId=" + warehouseId
+                            + "&asOfDate=2026-03-20&format=csv",
+                    adminHeaders);
+            assertCsvResponse(response);
+        }
     }
 
     // ========================================================
@@ -485,7 +573,9 @@ class ReportInboundIntegrationTest extends IntegrationTestBase {
         @Test
         @DisplayName("正常系: 確定済リストが返る")
         void getUnreceivedConfirmed_records_returnsItems() throws Exception {
-            insertUnreceivedListRecord(LocalDate.of(2026, 3, 20), "INB-RPT06-001",
+            Long slipId = insertInboundSlip("INB-RPT06-001", LocalDate.of(2026, 3, 19), "PLANNED",
+                    productAmbId, "AMB-001", "ミネラルウォーター", 10, null, null, "PENDING");
+            insertUnreceivedListRecord(LocalDate.of(2026, 3, 20), slipId, "INB-RPT06-001",
                     LocalDate.of(2026, 3, 19), 10, "PLANNED");
 
             ResponseEntity<String> response = get(
@@ -514,7 +604,9 @@ class ReportInboundIntegrationTest extends IntegrationTestBase {
         @Test
         @DisplayName("正常系: PDF形式で200")
         void getUnreceivedConfirmed_pdf_returnsBinary() {
-            insertUnreceivedListRecord(LocalDate.of(2026, 3, 20), "INB-RPT06-PDF",
+            Long slipId = insertInboundSlip("INB-RPT06-PDF", LocalDate.of(2026, 3, 19), "PLANNED",
+                    productAmbId, "AMB-001", "ミネラルウォーター", 10, null, null, "PENDING");
+            insertUnreceivedListRecord(LocalDate.of(2026, 3, 20), slipId, "INB-RPT06-PDF",
                     LocalDate.of(2026, 3, 19), 10, "PLANNED");
 
             ResponseEntity<byte[]> response = getBytes(
@@ -532,6 +624,29 @@ class ReportInboundIntegrationTest extends IntegrationTestBase {
                             + "&batchBusinessDate=2026-03-20&format=json",
                     adminHeaders);
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("権限: VIEWERでも閲覧可能 / 未認証で401")
+        void getUnreceivedConfirmed_authChecks() {
+            String url = "/api/v1/reports/unreceived-confirmed?warehouseId=" + warehouseId
+                    + "&batchBusinessDate=2026-03-20&format=json";
+            assertThat(get(url, viewerHeaders).getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(get(url, unauthHeaders()).getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        }
+
+        @Test
+        @DisplayName("正常系: CSV形式で200 + UTF-8 BOM")
+        void getUnreceivedConfirmed_csv_returnsCsv() {
+            Long slipId = insertInboundSlip("INB-RPT06-CSV", LocalDate.of(2026, 3, 19), "PLANNED",
+                    productAmbId, "AMB-001", "ミネラルウォーター", 10, null, null, "PENDING");
+            insertUnreceivedListRecord(LocalDate.of(2026, 3, 20), slipId, "INB-RPT06-CSV",
+                    LocalDate.of(2026, 3, 19), 10, "PLANNED");
+            ResponseEntity<byte[]> response = getBytes(
+                    "/api/v1/reports/unreceived-confirmed?warehouseId=" + warehouseId
+                            + "&batchBusinessDate=2026-03-20&format=csv",
+                    adminHeaders);
+            assertCsvResponse(response);
         }
     }
 }

--- a/backend/src/test/java/com/wms/report/controller/ReportInventoryIntegrationTest.java
+++ b/backend/src/test/java/com/wms/report/controller/ReportInventoryIntegrationTest.java
@@ -37,7 +37,6 @@ class ReportInventoryIntegrationTest extends IntegrationTestBase {
 
     private Long warehouseId;
     private Long buildingAId;
-    private Long areaA01Id;
     private Long locA01_01_01_01;
     private Long locA01_01_01_02;
     private Long productAmbId;
@@ -51,9 +50,6 @@ class ReportInventoryIntegrationTest extends IntegrationTestBase {
         buildingAId = jdbcTemplate.queryForObject(
                 "SELECT id FROM buildings WHERE building_code = 'A' AND warehouse_id = ?",
                 Long.class, warehouseId);
-        areaA01Id = jdbcTemplate.queryForObject(
-                "SELECT id FROM areas WHERE area_code = 'A01' AND building_id = ?",
-                Long.class, buildingAId);
         locA01_01_01_01 = jdbcTemplate.queryForObject(
                 "SELECT id FROM locations WHERE location_code = 'A-01-A01-01-01-01' AND warehouse_id = ?",
                 Long.class, warehouseId);
@@ -167,6 +163,25 @@ class ReportInventoryIntegrationTest extends IntegrationTestBase {
         assertThat(new String(body, 0, 4)).isEqualTo("%PDF");
     }
 
+    private void assertCsvResponse(ResponseEntity<byte[]> response) {
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getHeaders().getContentType())
+                .isNotNull()
+                .satisfies(ct -> assertThat(ct.toString()).contains("text/csv"));
+        byte[] body = response.getBody();
+        assertThat(body).isNotNull();
+        assertThat(body.length).isGreaterThanOrEqualTo(3);
+        assertThat(body[0]).isEqualTo((byte) 0xEF);
+        assertThat(body[1]).isEqualTo((byte) 0xBB);
+        assertThat(body[2]).isEqualTo((byte) 0xBF);
+    }
+
+    private HttpHeaders unauthHeaders() {
+        HttpHeaders h = new HttpHeaders();
+        h.setAccept(java.util.List.of(org.springframework.http.MediaType.APPLICATION_JSON));
+        return h;
+    }
+
     // ========================================================
     // RPT-07: 在庫一覧レポート
     // ========================================================
@@ -176,7 +191,7 @@ class ReportInventoryIntegrationTest extends IntegrationTestBase {
     class InventoryReport {
 
         @Test
-        @DisplayName("正常系: 在庫データが返る（available = quantity - allocated）")
+        @DisplayName("正常系: 在庫データが返る（available = quantity - allocated を全件で検証）")
         void getInventory_data_returnsItems() throws Exception {
             insertInventory(locA01_01_01_01, productAmbId, "PIECE", 100, 30);
             insertInventory(locA01_01_01_02, productAmb2Id, "PIECE", 50, 0);
@@ -188,9 +203,15 @@ class ReportInventoryIntegrationTest extends IntegrationTestBase {
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
             JsonNode body = parseJson(response.getBody());
             assertThat(body).hasSize(2);
-            JsonNode first = body.get(0);
-            assertThat(first.get("availableQty").asInt())
-                    .isEqualTo(first.get("quantity").asInt() - first.get("allocatedQty").asInt());
+            // 全件で available = quantity - allocated を検証
+            for (JsonNode row : body) {
+                assertThat(row.get("availableQty").asInt())
+                        .isEqualTo(row.get("quantity").asInt() - row.get("allocatedQty").asInt());
+            }
+            // 投入した両商品コードが含まれる
+            java.util.Set<String> codes = new java.util.HashSet<>();
+            body.forEach(row -> codes.add(row.get("productCode").asText()));
+            assertThat(codes).containsExactlyInAnyOrder("AMB-001", "AMB-002");
         }
 
         @Test
@@ -238,12 +259,21 @@ class ReportInventoryIntegrationTest extends IntegrationTestBase {
         }
 
         @Test
-        @DisplayName("権限: VIEWERでも閲覧可能")
-        void getInventory_viewer_succeeds() {
-            ResponseEntity<String> response = get(
-                    "/api/v1/reports/inventory?warehouseId=" + warehouseId + "&format=json",
-                    viewerHeaders);
-            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        @DisplayName("権限: VIEWERでも閲覧可能 / 未認証で401")
+        void getInventory_authChecks() {
+            String url = "/api/v1/reports/inventory?warehouseId=" + warehouseId + "&format=json";
+            assertThat(get(url, viewerHeaders).getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(get(url, unauthHeaders()).getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        }
+
+        @Test
+        @DisplayName("正常系: CSV形式で200 + UTF-8 BOM")
+        void getInventory_csv_returnsCsv() {
+            insertInventory(locA01_01_01_01, productAmbId, "PIECE", 100, 0);
+            ResponseEntity<byte[]> response = getBytes(
+                    "/api/v1/reports/inventory?warehouseId=" + warehouseId + "&format=csv",
+                    adminHeaders);
+            assertCsvResponse(response);
         }
     }
 
@@ -323,6 +353,29 @@ class ReportInventoryIntegrationTest extends IntegrationTestBase {
             assertThat(parseJson(response.getBody()).get("code").asText())
                     .isEqualTo("PRODUCT_NOT_FOUND");
         }
+
+        @Test
+        @DisplayName("権限: VIEWERでも閲覧可能 / 未認証で401")
+        void getTransition_authChecks() {
+            String url = "/api/v1/reports/inventory-transition?warehouseId=" + warehouseId
+                    + "&productId=" + productAmbId + "&format=json";
+            assertThat(get(url, viewerHeaders).getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(get(url, unauthHeaders()).getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        }
+
+        @Test
+        @DisplayName("正常系: CSV形式で200 + UTF-8 BOM")
+        void getTransition_csv_returnsCsv() {
+            insertInventoryMovement(locA01_01_01_01, "A-01-A01-01-01-01", productAmbId,
+                    "AMB-001", "ミネラルウォーター", "INBOUND", 50, 50,
+                    "2026-03-20T10:00:00+09:00", null);
+            ResponseEntity<byte[]> response = getBytes(
+                    "/api/v1/reports/inventory-transition?warehouseId=" + warehouseId
+                            + "&productId=" + productAmbId
+                            + "&dateFrom=2026-03-20&dateTo=2026-03-20&format=csv",
+                    adminHeaders);
+            assertCsvResponse(response);
+        }
     }
 
     // ========================================================
@@ -392,6 +445,37 @@ class ReportInventoryIntegrationTest extends IntegrationTestBase {
                     "/api/v1/reports/inventory-correction?warehouseId=99999999&format=json",
                     adminHeaders);
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("正常系: データ0件で空配列")
+        void getCorrection_noData_returnsEmpty() throws Exception {
+            ResponseEntity<String> response = get(
+                    "/api/v1/reports/inventory-correction?warehouseId=" + warehouseId + "&format=json",
+                    adminHeaders);
+            assertThat(parseJson(response.getBody())).isEmpty();
+        }
+
+        @Test
+        @DisplayName("権限: VIEWERでも閲覧可能 / 未認証で401")
+        void getCorrection_authChecks() {
+            String url = "/api/v1/reports/inventory-correction?warehouseId=" + warehouseId
+                    + "&format=json";
+            assertThat(get(url, viewerHeaders).getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(get(url, unauthHeaders()).getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        }
+
+        @Test
+        @DisplayName("正常系: CSV形式で200 + UTF-8 BOM")
+        void getCorrection_csv_returnsCsv() {
+            insertInventoryMovement(locA01_01_01_01, "A-01-A01-01-01-01", productAmbId,
+                    "AMB-001", "ミネラルウォーター", "CORRECTION", 5, 105,
+                    "2026-03-20T10:00:00+09:00", "差異補正");
+            ResponseEntity<byte[]> response = getBytes(
+                    "/api/v1/reports/inventory-correction?warehouseId=" + warehouseId
+                            + "&correctionDateFrom=2026-03-20&correctionDateTo=2026-03-20&format=csv",
+                    adminHeaders);
+            assertCsvResponse(response);
         }
     }
 
@@ -467,6 +551,27 @@ class ReportInventoryIntegrationTest extends IntegrationTestBase {
                     adminHeaders);
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
         }
+
+        @Test
+        @DisplayName("権限: VIEWERでも閲覧可能 / 未認証で401")
+        void getStocktakeList_authChecks() {
+            Long stocktakeId = insertStocktake("ST-RPT10-AUTH", "STARTED", false, false);
+            String url = "/api/v1/reports/stocktake-list?stocktakeId=" + stocktakeId
+                    + "&hideBookQty=true&format=json";
+            assertThat(get(url, viewerHeaders).getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(get(url, unauthHeaders()).getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        }
+
+        @Test
+        @DisplayName("正常系: CSV形式で200 + UTF-8 BOM")
+        void getStocktakeList_csv_returnsCsv() {
+            Long stocktakeId = insertStocktake("ST-RPT10-CSV", "STARTED", false, false);
+            ResponseEntity<byte[]> response = getBytes(
+                    "/api/v1/reports/stocktake-list?stocktakeId=" + stocktakeId
+                            + "&hideBookQty=true&format=csv",
+                    adminHeaders);
+            assertCsvResponse(response);
+        }
     }
 
     // ========================================================
@@ -512,6 +617,25 @@ class ReportInventoryIntegrationTest extends IntegrationTestBase {
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
             assertThat(parseJson(response.getBody()).get("code").asText())
                     .isEqualTo("STOCKTAKE_NOT_FOUND");
+        }
+
+        @Test
+        @DisplayName("権限: VIEWERでも閲覧可能 / 未認証で401")
+        void getStocktakeResult_authChecks() {
+            Long stocktakeId = insertStocktake("ST-RPT11-AUTH", "CONFIRMED", true, false);
+            String url = "/api/v1/reports/stocktake-result?stocktakeId=" + stocktakeId + "&format=json";
+            assertThat(get(url, viewerHeaders).getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(get(url, unauthHeaders()).getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        }
+
+        @Test
+        @DisplayName("正常系: CSV形式で200 + UTF-8 BOM")
+        void getStocktakeResult_csv_returnsCsv() {
+            Long stocktakeId = insertStocktake("ST-RPT11-CSV", "CONFIRMED", true, true);
+            ResponseEntity<byte[]> response = getBytes(
+                    "/api/v1/reports/stocktake-result?stocktakeId=" + stocktakeId + "&format=csv",
+                    adminHeaders);
+            assertCsvResponse(response);
         }
     }
 }

--- a/backend/src/test/java/com/wms/report/controller/ReportMiscIntegrationTest.java
+++ b/backend/src/test/java/com/wms/report/controller/ReportMiscIntegrationTest.java
@@ -138,6 +138,25 @@ class ReportMiscIntegrationTest extends IntegrationTestBase {
         assertThat(new String(body, 0, 4)).isEqualTo("%PDF");
     }
 
+    private void assertCsvResponse(ResponseEntity<byte[]> response) {
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getHeaders().getContentType())
+                .isNotNull()
+                .satisfies(ct -> assertThat(ct.toString()).contains("text/csv"));
+        byte[] body = response.getBody();
+        assertThat(body).isNotNull();
+        assertThat(body.length).isGreaterThanOrEqualTo(3);
+        assertThat(body[0]).isEqualTo((byte) 0xEF);
+        assertThat(body[1]).isEqualTo((byte) 0xBB);
+        assertThat(body[2]).isEqualTo((byte) 0xBF);
+    }
+
+    private HttpHeaders unauthHeaders() {
+        HttpHeaders h = new HttpHeaders();
+        h.setAccept(java.util.List.of(org.springframework.http.MediaType.APPLICATION_JSON));
+        return h;
+    }
+
     // ========================================================
     // RPT-17: 日次集計レポート
     // ========================================================
@@ -202,6 +221,27 @@ class ReportMiscIntegrationTest extends IntegrationTestBase {
                     "/api/v1/reports/daily-summary?targetBusinessDate=2026-03-20&format=json",
                     viewerHeaders);
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        }
+
+        @Test
+        @DisplayName("権限: 未認証で401")
+        void getDailySummary_unauthenticated_returns401() {
+            ResponseEntity<String> response = get(
+                    "/api/v1/reports/daily-summary?targetBusinessDate=2026-03-20&format=json",
+                    unauthHeaders());
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        }
+
+        @Test
+        @DisplayName("正常系: CSV形式で200 + UTF-8 BOM")
+        void getDailySummary_csv_returnsCsv() {
+            LocalDate businessDate = LocalDate.of(2026, 3, 20);
+            insertBatchLogSuccess(businessDate);
+            insertDailySummary(businessDate, 5, 3, 0, 0);
+            ResponseEntity<byte[]> response = getBytes(
+                    "/api/v1/reports/daily-summary?targetBusinessDate=2026-03-20&format=csv",
+                    adminHeaders);
+            assertCsvResponse(response);
         }
     }
 
@@ -298,6 +338,25 @@ class ReportMiscIntegrationTest extends IntegrationTestBase {
                     "/api/v1/reports/returns?warehouseId=99999999&format=json",
                     adminHeaders);
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("権限: VIEWERでも閲覧可能 / 未認証で401")
+        void getReturns_authChecks() {
+            String url = "/api/v1/reports/returns?warehouseId=" + warehouseId + "&format=json";
+            assertThat(get(url, viewerHeaders).getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(get(url, unauthHeaders()).getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        }
+
+        @Test
+        @DisplayName("正常系: CSV形式で200 + UTF-8 BOM")
+        void getReturns_csv_returnsCsv() {
+            insertReturnSlip("RTN-RPT18-CSV", "INBOUND", LocalDate.of(2026, 3, 20),
+                    5, "QUALITY_DEFECT");
+            ResponseEntity<byte[]> response = getBytes(
+                    "/api/v1/reports/returns?warehouseId=" + warehouseId + "&format=csv",
+                    adminHeaders);
+            assertCsvResponse(response);
         }
     }
 }

--- a/backend/src/test/java/com/wms/report/controller/ReportOutboundIntegrationTest.java
+++ b/backend/src/test/java/com/wms/report/controller/ReportOutboundIntegrationTest.java
@@ -166,6 +166,25 @@ class ReportOutboundIntegrationTest extends IntegrationTestBase {
         assertThat(new String(body, 0, 4)).isEqualTo("%PDF");
     }
 
+    private void assertCsvResponse(ResponseEntity<byte[]> response) {
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getHeaders().getContentType())
+                .isNotNull()
+                .satisfies(ct -> assertThat(ct.toString()).contains("text/csv"));
+        byte[] body = response.getBody();
+        assertThat(body).isNotNull();
+        assertThat(body.length).isGreaterThanOrEqualTo(3);
+        assertThat(body[0]).isEqualTo((byte) 0xEF);
+        assertThat(body[1]).isEqualTo((byte) 0xBB);
+        assertThat(body[2]).isEqualTo((byte) 0xBF);
+    }
+
+    private HttpHeaders unauthHeaders() {
+        HttpHeaders h = new HttpHeaders();
+        h.setAccept(java.util.List.of(org.springframework.http.MediaType.APPLICATION_JSON));
+        return h;
+    }
+
     // ========================================================
     // RPT-12: ピッキング指示書
     // ========================================================
@@ -234,6 +253,29 @@ class ReportOutboundIntegrationTest extends IntegrationTestBase {
                     viewerHeaders);
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         }
+
+        @Test
+        @DisplayName("権限: 未認証で401")
+        void getPicking_unauthenticated_returns401() {
+            ResponseEntity<String> response = get(
+                    "/api/v1/reports/picking-instruction?pickingInstructionId=1&format=json",
+                    unauthHeaders());
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        }
+
+        @Test
+        @DisplayName("正常系: CSV形式で200 + UTF-8 BOM")
+        void getPicking_csv_returnsCsv() {
+            Long slipId = insertOutboundSlip("OUT-RPT12-CSV", LocalDate.of(2026, 3, 20),
+                    "PICKING_COMPLETED", null, null,
+                    productAmbId, "AMB-001", "ミネラルウォーター", 10, null, 0, "PICKING_COMPLETED");
+            Long instructionId = insertPickingInstruction("PI-RPT12-CSV", slipId, 10, 10);
+            ResponseEntity<byte[]> response = getBytes(
+                    "/api/v1/reports/picking-instruction?pickingInstructionId=" + instructionId
+                            + "&format=csv",
+                    adminHeaders);
+            assertCsvResponse(response);
+        }
     }
 
     // ========================================================
@@ -287,6 +329,29 @@ class ReportOutboundIntegrationTest extends IntegrationTestBase {
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
             assertThat(parseJson(response.getBody()).get("code").asText())
                     .isEqualTo("OUTBOUND_SLIP_NOT_FOUND");
+        }
+
+        @Test
+        @DisplayName("権限: VIEWERでも閲覧可能 / 未認証で401")
+        void getShippingInspection_authChecks() {
+            Long slipId = insertOutboundSlip("OUT-RPT13-AUTH", LocalDate.of(2026, 3, 20),
+                    "INSPECTING", null, null,
+                    productAmbId, "AMB-001", "ミネラルウォーター", 10, 10, 0, "PICKING_COMPLETED");
+            String url = "/api/v1/reports/shipping-inspection?slipId=" + slipId + "&format=json";
+            assertThat(get(url, viewerHeaders).getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(get(url, unauthHeaders()).getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        }
+
+        @Test
+        @DisplayName("正常系: CSV形式で200 + UTF-8 BOM")
+        void getShippingInspection_csv_returnsCsv() {
+            Long slipId = insertOutboundSlip("OUT-RPT13-CSV", LocalDate.of(2026, 3, 20),
+                    "INSPECTING", null, null,
+                    productAmbId, "AMB-001", "ミネラルウォーター", 10, 10, 0, "PICKING_COMPLETED");
+            ResponseEntity<byte[]> response = getBytes(
+                    "/api/v1/reports/shipping-inspection?slipId=" + slipId + "&format=csv",
+                    adminHeaders);
+            assertCsvResponse(response);
         }
     }
 
@@ -367,6 +432,25 @@ class ReportOutboundIntegrationTest extends IntegrationTestBase {
                     adminHeaders);
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
         }
+
+        @Test
+        @DisplayName("権限: VIEWERでも閲覧可能 / 未認証で401")
+        void getDeliveryList_authChecks() {
+            String url = "/api/v1/reports/delivery-list?warehouseId=" + warehouseId + "&format=json";
+            assertThat(get(url, viewerHeaders).getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(get(url, unauthHeaders()).getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        }
+
+        @Test
+        @DisplayName("正常系: CSV形式で200 + UTF-8 BOM")
+        void getDeliveryList_csv_returnsCsv() {
+            insertOutboundSlip("OUT-RPT14-CSV", LocalDate.of(2026, 3, 20), "ALLOCATED",
+                    null, null, productAmbId, "AMB-001", "ミネラルウォーター", 10, null, 0, "ALLOCATED");
+            ResponseEntity<byte[]> response = getBytes(
+                    "/api/v1/reports/delivery-list?warehouseId=" + warehouseId + "&format=csv",
+                    adminHeaders);
+            assertCsvResponse(response);
+        }
     }
 
     // ========================================================
@@ -418,6 +502,37 @@ class ReportOutboundIntegrationTest extends IntegrationTestBase {
                     "/api/v1/reports/unshipped-realtime?warehouseId=99999999&format=json",
                     adminHeaders);
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("正常系: データ0件で空配列")
+        void getUnshippedRealtime_noData_returnsEmpty() throws Exception {
+            ResponseEntity<String> response = get(
+                    "/api/v1/reports/unshipped-realtime?warehouseId=" + warehouseId
+                            + "&asOfDate=2026-03-20&format=json",
+                    adminHeaders);
+            assertThat(parseJson(response.getBody())).isEmpty();
+        }
+
+        @Test
+        @DisplayName("権限: VIEWERでも閲覧可能 / 未認証で401")
+        void getUnshippedRealtime_authChecks() {
+            String url = "/api/v1/reports/unshipped-realtime?warehouseId=" + warehouseId
+                    + "&asOfDate=2026-03-20&format=json";
+            assertThat(get(url, viewerHeaders).getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(get(url, unauthHeaders()).getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        }
+
+        @Test
+        @DisplayName("正常系: CSV形式で200 + UTF-8 BOM")
+        void getUnshippedRealtime_csv_returnsCsv() {
+            insertOutboundSlip("OUT-RPT15-CSV", LocalDate.of(2026, 3, 19), "ALLOCATED",
+                    null, null, productAmbId, "AMB-001", "ミネラルウォーター", 10, null, 0, "ALLOCATED");
+            ResponseEntity<byte[]> response = getBytes(
+                    "/api/v1/reports/unshipped-realtime?warehouseId=" + warehouseId
+                            + "&asOfDate=2026-03-20&format=csv",
+                    adminHeaders);
+            assertCsvResponse(response);
         }
     }
 
@@ -483,6 +598,29 @@ class ReportOutboundIntegrationTest extends IntegrationTestBase {
                             + "&batchBusinessDate=2026-03-20&format=json",
                     adminHeaders);
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("権限: VIEWERでも閲覧可能 / 未認証で401")
+        void getUnshippedConfirmed_authChecks() {
+            String url = "/api/v1/reports/unshipped-confirmed?warehouseId=" + warehouseId
+                    + "&batchBusinessDate=2026-03-20&format=json";
+            assertThat(get(url, viewerHeaders).getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(get(url, unauthHeaders()).getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        }
+
+        @Test
+        @DisplayName("正常系: CSV形式で200 + UTF-8 BOM")
+        void getUnshippedConfirmed_csv_returnsCsv() {
+            Long slipId = insertOutboundSlip("OUT-RPT16-CSV", LocalDate.of(2026, 3, 19), "ALLOCATED",
+                    null, null, productAmbId, "AMB-001", "ミネラルウォーター", 10, null, 0, "ALLOCATED");
+            insertUnshippedListRecord(LocalDate.of(2026, 3, 20), slipId, "OUT-RPT16-CSV",
+                    LocalDate.of(2026, 3, 19), 10, "ALLOCATED");
+            ResponseEntity<byte[]> response = getBytes(
+                    "/api/v1/reports/unshipped-confirmed?warehouseId=" + warehouseId
+                            + "&batchBusinessDate=2026-03-20&format=csv",
+                    adminHeaders);
+            assertCsvResponse(response);
         }
     }
 }


### PR DESCRIPTION
Closes #397

## Summary
- 帳票API（RPT-01〜RPT-18、全17レポート）の結合テストを4ファイルに分割して追加
- JSON出力 / PDF出力 / 絞り込み / 0件 / 404 / ロール制御を共通的にカバー

## ファイル構成

| ファイル | 対象 |
|---------|------|
| ReportInboundIntegrationTest | RPT-01,03,04,05,06（入荷系） |
| ReportInventoryIntegrationTest | RPT-07,08,09,10,11（在庫・棚卸系） |
| ReportOutboundIntegrationTest | RPT-12,13,14,15,16（出荷系） |
| ReportMiscIntegrationTest | RPT-17,18（日次集計・返品） |

## テスト仕様
- 設計書: \`docs/test-specifications/TST-RPT-reports.md\`
- IntegrationTestBase（Testcontainers + PostgreSQL）を継承
- テストデータはJDBC直接INSERTで投入
- 全テストにJUnit 5 \`@Tag(\"integration\")\` を継承

## カバー範囲（各レポート共通）
- ✅ JSON形式正常系（DBデータとの突合）
- ✅ PDF形式正常系（Content-Type: application/pdf, %PDFマジックバイト）
- ✅ 検索パラメータ絞り込み（該当する場合）
- ✅ データ0件時の空配列レスポンス
- ✅ 404エラー（RPT-01/10/11/12/13/17 など、リソース未存在シナリオ）
- ✅ VIEWER ロール閲覧可能

## Test plan
- [ ] \`./gradlew integrationTest\` で4テストクラス全件パス確認（要Docker環境）
- [ ] PR本文の表示確認

> Note: ローカル環境にDockerが無いため、結合テスト実行はマージ前にDocker環境で実施をお願いします。コードレベルでは \`./gradlew compileTestJava\` 成功を確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)