### PR TITLE
refactor: 全モジュール BR/OL 例外メッセージから内部 id 除去 (#445)

### DIFF
--- a/backend/src/main/java/com/wms/allocation/service/AllocationService.java
+++ b/backend/src/main/java/com/wms/allocation/service/AllocationService.java
@@ -121,14 +121,20 @@ public class AllocationService {
         List<UnallocatedLineInfo> unallocatedLines = new ArrayList<>();
 
         for (Long slipId : slipIds) {
+            final Long currentSlipId = slipId;
             OutboundSlip slip = outboundSlipRepository.findByIdForUpdate(slipId)
-                    .orElseThrow(() -> new ResourceNotFoundException(
-                            "OUTBOUND_SLIP_NOT_FOUND",
-                            "出荷伝票が見つかりません (id=" + slipId + ")"));
+                    .orElseThrow(() -> {
+                        // SEC-R2-Min-1 (OWASP A09): 追跡用 id はログへ、メッセージからは除去
+                        log.info("OutboundSlip not found on allocation execute: slipId={}", currentSlipId);
+                        return new ResourceNotFoundException(
+                                "OUTBOUND_SLIP_NOT_FOUND",
+                                "出荷伝票が見つかりません");
+                    });
 
             if (!ALLOCATABLE_STATUSES.contains(slip.getStatus())) {
+                log.info("OutboundSlip not allocatable: slipId={}, status={}", currentSlipId, slip.getStatus());
                 throw new InvalidStateTransitionException("OUTBOUND_INVALID_STATUS",
-                        "引当可能なステータスではありません (id=" + slipId + ", status=" + slip.getStatus() + ")");
+                        "引当可能なステータスではありません (status=" + slip.getStatus() + ")");
             }
 
             List<AllocatedLineInfo> allocatedLines = new ArrayList<>();
@@ -242,9 +248,13 @@ public class AllocationService {
                 continue;
             }
 
-            Inventory locked = inventoryRepository.findByIdForUpdate(stock.getId())
-                    .orElseThrow(() -> new ResourceNotFoundException("INVENTORY_NOT_FOUND",
-                            "在庫が見つかりません (id=" + stock.getId() + ")"));
+            final Long stockId = stock.getId();
+            Inventory locked = inventoryRepository.findByIdForUpdate(stockId)
+                    .orElseThrow(() -> {
+                        log.info("Inventory not found during allocation: inventoryId={}", stockId);
+                        return new ResourceNotFoundException("INVENTORY_NOT_FOUND",
+                                "在庫が見つかりません");
+                    });
 
             // 再計算（ロック後に在庫が変わっている可能性）
             available = locked.getQuantity() - locked.getAllocatedQty();
@@ -312,9 +322,13 @@ public class AllocationService {
             int toQty = fromQty * conversionRate;
             int allocateQty = Math.min(toQty, remaining);
 
-            Inventory locked = inventoryRepository.findByIdForUpdate(stock.getId())
-                    .orElseThrow(() -> new ResourceNotFoundException("INVENTORY_NOT_FOUND",
-                            "在庫が見つかりません (id=" + stock.getId() + ")"));
+            final Long stockId = stock.getId();
+            Inventory locked = inventoryRepository.findByIdForUpdate(stockId)
+                    .orElseThrow(() -> {
+                        log.info("Inventory not found during allocation: inventoryId={}", stockId);
+                        return new ResourceNotFoundException("INVENTORY_NOT_FOUND",
+                                "在庫が見つかりません");
+                    });
 
             available = locked.getQuantity() - locked.getAllocatedQty();
             fromQty = Math.min(available, neededFromQty);
@@ -396,31 +410,42 @@ public class AllocationService {
     @Transactional
     public UnpackCompletionInfo completeUnpackInstruction(Long id) {
         UnpackInstruction unpack = unpackInstructionRepository.findById(id)
-                .orElseThrow(() -> new ResourceNotFoundException(
-                        "BREAKDOWN_INSTRUCTION_NOT_FOUND",
-                        "ばらし指示が見つかりません (id=" + id + ")"));
+                .orElseThrow(() -> {
+                    log.info("UnpackInstruction not found on complete: id={}", id);
+                    return new ResourceNotFoundException(
+                            "BREAKDOWN_INSTRUCTION_NOT_FOUND",
+                            "ばらし指示が見つかりません");
+                });
 
         if (!"INSTRUCTED".equals(unpack.getStatus())) {
+            log.info("UnpackInstruction already completed: id={}, status={}", id, unpack.getStatus());
             throw new InvalidStateTransitionException("ALREADY_COMPLETED",
-                    "既に完了済みのばらし指示です (id=" + id + ", status=" + unpack.getStatus() + ")");
+                    "既に完了済みのばらし指示です (status=" + unpack.getStatus() + ")");
         }
 
         Product product = productService.findById(unpack.getProductId());
         Location location = locationRepository.findById(unpack.getLocationId())
-                .orElseThrow(() -> new ResourceNotFoundException("LOCATION_NOT_FOUND",
-                        "ロケーションが見つかりません (id=" + unpack.getLocationId() + ")"));
+                .orElseThrow(() -> {
+                    log.info("Location not found on unpack complete: locationId={}", unpack.getLocationId());
+                    return new ResourceNotFoundException("LOCATION_NOT_FOUND",
+                            "ロケーションが見つかりません");
+                });
 
         Long currentUserId = getCurrentUserId();
         OffsetDateTime now = OffsetDateTime.now();
 
         // Step1-2: ばらし元在庫のallocated_qtyとquantityを減算
         if (unpack.getSourceInventoryId() == null) {
+            log.info("Unpack source inventory id missing: unpackId={}", unpack.getId());
             throw new BusinessRuleViolationException("SOURCE_INVENTORY_ID_MISSING",
-                    "ばらし指示に元在庫IDが設定されていません (unpackId=" + unpack.getId() + ")");
+                    "ばらし指示に元在庫IDが設定されていません");
         }
         Inventory lockedSource = inventoryRepository.findByIdForUpdate(unpack.getSourceInventoryId())
-                .orElseThrow(() -> new ResourceNotFoundException("INVENTORY_NOT_FOUND",
-                        "ばらし元在庫が見つかりません (id=" + unpack.getSourceInventoryId() + ")"));
+                .orElseThrow(() -> {
+                    log.info("Unpack source inventory not found: sourceInventoryId={}", unpack.getSourceInventoryId());
+                    return new ResourceNotFoundException("INVENTORY_NOT_FOUND",
+                            "ばらし元在庫が見つかりません");
+                });
 
         lockedSource.setAllocatedQty(lockedSource.getAllocatedQty() - unpack.getFromQty());
         lockedSource.setQuantity(lockedSource.getQuantity() - unpack.getFromQty());
@@ -555,14 +580,19 @@ public class AllocationService {
         List<ReleasedSlipInfo> releasedSlips = new ArrayList<>();
 
         for (Long slipId : slipIds) {
+            final Long currentSlipId = slipId;
             OutboundSlip slip = outboundSlipRepository.findByIdForUpdate(slipId)
-                    .orElseThrow(() -> new ResourceNotFoundException(
-                            "OUTBOUND_SLIP_NOT_FOUND",
-                            "出荷伝票が見つかりません (id=" + slipId + ")"));
+                    .orElseThrow(() -> {
+                        log.info("OutboundSlip not found on release: slipId={}", currentSlipId);
+                        return new ResourceNotFoundException(
+                                "OUTBOUND_SLIP_NOT_FOUND",
+                                "出荷伝票が見つかりません");
+                    });
 
             if (!RELEASABLE_STATUSES.contains(slip.getStatus())) {
+                log.info("OutboundSlip not releasable: slipId={}, status={}", currentSlipId, slip.getStatus());
                 throw new InvalidStateTransitionException("RELEASE_NOT_ALLOWED",
-                        "引当解放可能なステータスではありません (id=" + slipId + ", status=" + slip.getStatus() + ")");
+                        "引当解放可能なステータスではありません (status=" + slip.getStatus() + ")");
             }
 
             String previousStatus = slip.getStatus();

--- a/backend/src/main/java/com/wms/allocation/service/AllocationService.java
+++ b/backend/src/main/java/com/wms/allocation/service/AllocationService.java
@@ -121,20 +121,19 @@ public class AllocationService {
         List<UnallocatedLineInfo> unallocatedLines = new ArrayList<>();
 
         for (Long slipId : slipIds) {
-            final Long currentSlipId = slipId;
             OutboundSlip slip = outboundSlipRepository.findByIdForUpdate(slipId)
                     .orElseThrow(() -> {
                         // SEC-R2-Min-1 (OWASP A09): 追跡用 id はログへ、メッセージからは除去
-                        log.info("OutboundSlip not found on allocation execute: slipId={}", currentSlipId);
+                        log.info("OutboundSlip not found on allocation execute: slipId={}", slipId);
                         return new ResourceNotFoundException(
                                 "OUTBOUND_SLIP_NOT_FOUND",
                                 "出荷伝票が見つかりません");
                     });
 
             if (!ALLOCATABLE_STATUSES.contains(slip.getStatus())) {
-                log.info("OutboundSlip not allocatable: slipId={}, status={}", currentSlipId, slip.getStatus());
+                log.info("OutboundSlip not allocatable: slipId={}, status={}", slipId, slip.getStatus());
                 throw new InvalidStateTransitionException("OUTBOUND_INVALID_STATUS",
-                        "引当可能なステータスではありません (status=" + slip.getStatus() + ")");
+                        "現在のステータスでは引当できません");
             }
 
             List<AllocatedLineInfo> allocatedLines = new ArrayList<>();
@@ -420,7 +419,7 @@ public class AllocationService {
         if (!"INSTRUCTED".equals(unpack.getStatus())) {
             log.info("UnpackInstruction already completed: id={}, status={}", id, unpack.getStatus());
             throw new InvalidStateTransitionException("ALREADY_COMPLETED",
-                    "既に完了済みのばらし指示です (status=" + unpack.getStatus() + ")");
+                    "既に完了済みのばらし指示です");
         }
 
         Product product = productService.findById(unpack.getProductId());
@@ -580,19 +579,18 @@ public class AllocationService {
         List<ReleasedSlipInfo> releasedSlips = new ArrayList<>();
 
         for (Long slipId : slipIds) {
-            final Long currentSlipId = slipId;
             OutboundSlip slip = outboundSlipRepository.findByIdForUpdate(slipId)
                     .orElseThrow(() -> {
-                        log.info("OutboundSlip not found on release: slipId={}", currentSlipId);
+                        log.info("OutboundSlip not found on release: slipId={}", slipId);
                         return new ResourceNotFoundException(
                                 "OUTBOUND_SLIP_NOT_FOUND",
                                 "出荷伝票が見つかりません");
                     });
 
             if (!RELEASABLE_STATUSES.contains(slip.getStatus())) {
-                log.info("OutboundSlip not releasable: slipId={}, status={}", currentSlipId, slip.getStatus());
+                log.info("OutboundSlip not releasable: slipId={}, status={}", slipId, slip.getStatus());
                 throw new InvalidStateTransitionException("RELEASE_NOT_ALLOWED",
-                        "引当解放可能なステータスではありません (status=" + slip.getStatus() + ")");
+                        "現在のステータスでは引当を解放できません");
             }
 
             String previousStatus = slip.getStatus();

--- a/backend/src/main/java/com/wms/batch/controller/BatchController.java
+++ b/backend/src/main/java/com/wms/batch/controller/BatchController.java
@@ -65,9 +65,13 @@ public class BatchController implements BatchApi {
     @Override
     public ResponseEntity<BatchExecutionDetail> getBatchExecution(Long id) {
         BatchExecutionLog logEntry = logRepository.findById(id)
-                .orElseThrow(() -> new ResourceNotFoundException(
-                        "BATCH_EXECUTION_NOT_FOUND",
-                        "指定されたバッチ実行履歴が見つかりません (id=" + id + ")"));
+                .orElseThrow(() -> {
+                    // SEC-R2-Min-1 (OWASP A09): 追跡用 id はログへ、クライアント向けメッセージから除去
+                    log.info("BatchExecutionLog not found: id={}", id);
+                    return new ResourceNotFoundException(
+                            "BATCH_EXECUTION_NOT_FOUND",
+                            "指定されたバッチ実行履歴が見つかりません");
+                });
         return ResponseEntity.ok(toDetail(logEntry));
     }
 

--- a/backend/src/main/java/com/wms/inbound/service/InboundSlipService.java
+++ b/backend/src/main/java/com/wms/inbound/service/InboundSlipService.java
@@ -110,16 +110,24 @@ public class InboundSlipService {
 
     public InboundSlip findById(Long id) {
         return inboundSlipRepository.findById(id)
-                .orElseThrow(() -> new ResourceNotFoundException(
-                        "INBOUND_SLIP_NOT_FOUND",
-                        "入荷伝票が見つかりません (id=" + id + ")"));
+                .orElseThrow(() -> {
+                    // SEC-R2-Min-1 (OWASP A09): 例外メッセージには内部 id を含めない。
+                    // 追跡用の id はログ側に出力する。
+                    log.info("InboundSlip not found: id={}", id);
+                    return new ResourceNotFoundException(
+                            "INBOUND_SLIP_NOT_FOUND",
+                            "入荷伝票が見つかりません");
+                });
     }
 
     public InboundSlip findByIdWithLines(Long id) {
         return inboundSlipRepository.findByIdWithLines(id)
-                .orElseThrow(() -> new ResourceNotFoundException(
-                        "INBOUND_SLIP_NOT_FOUND",
-                        "入荷伝票が見つかりません (id=" + id + ")"));
+                .orElseThrow(() -> {
+                    log.info("InboundSlip not found (withLines): id={}", id);
+                    return new ResourceNotFoundException(
+                            "INBOUND_SLIP_NOT_FOUND",
+                            "入荷伝票が見つかりません");
+                });
     }
 
     public long countLinesBySlipId(Long slipId) {
@@ -334,11 +342,13 @@ public class InboundSlipService {
         }
 
         // Duplicate lineId check
+        // SEC-R2-Min-1 (OWASP A09): 例外メッセージからは内部 lineId を除去し、log 側に出力する。
         Set<Long> inspectLineIds = new HashSet<>();
         for (InspectLineRequest lineReq : request.getLines()) {
             if (!inspectLineIds.add(lineReq.getLineId())) {
+                log.warn("InboundSlip inspect duplicate lineId: slipId={}, lineId={}", id, lineReq.getLineId());
                 throw new BusinessRuleViolationException("DUPLICATE_LINE_IN_REQUEST",
-                        "リクエスト内に同じ明細IDが重複しています (lineId=" + lineReq.getLineId() + ")");
+                        "リクエスト内に同じ明細が重複しています");
             }
         }
 
@@ -349,18 +359,24 @@ public class InboundSlipService {
             InboundSlipLine line = slip.getLines().stream()
                     .filter(l -> l.getId().equals(lineReq.getLineId()))
                     .findFirst()
-                    .orElseThrow(() -> new ResourceNotFoundException("INBOUND_LINE_NOT_FOUND",
-                            "入荷伝票明細が見つかりません (lineId=" + lineReq.getLineId() + ")"));
+                    .orElseThrow(() -> {
+                        log.info("InboundSlip inspect line not found: slipId={}, lineId={}", id, lineReq.getLineId());
+                        return new ResourceNotFoundException("INBOUND_LINE_NOT_FOUND",
+                                "入荷伝票明細が見つかりません");
+                    });
 
             if (InboundLineStatus.STORED.getValue().equals(line.getLineStatus())) {
+                log.info("InboundSlip inspect already stored: slipId={}, lineId={}", id, line.getId());
                 throw new InvalidStateTransitionException("INBOUND_LINE_ALREADY_STORED",
-                        "格納済みの明細は検品できません (lineId=" + line.getId() + ")");
+                        "格納済みの明細は検品できません");
             }
 
             if (lineReq.getInspectedQty() < 0) {
+                log.info("InboundSlip inspect negative qty: slipId={}, lineId={}, inspectedQty={}",
+                        id, line.getId(), lineReq.getInspectedQty());
                 throw new BusinessRuleViolationException("INBOUND_INSPECTED_QTY_NEGATIVE",
-                        "検品数は0以上である必要があります (lineId=" + line.getId()
-                                + ", inspectedQty=" + lineReq.getInspectedQty() + ")");
+                        "検品数は0以上である必要があります (inspectedQty="
+                                + lineReq.getInspectedQty() + ")");
             }
 
             line.setInspectedQty(lineReq.getInspectedQty());
@@ -391,11 +407,13 @@ public class InboundSlipService {
         }
 
         // Duplicate lineId check
+        // SEC-R2-Min-1 (OWASP A09): 例外メッセージからは内部 lineId を除去し、log 側に出力する。
         Set<Long> storeLineIds = new HashSet<>();
         for (StoreLineRequest lineReq : request.getLines()) {
             if (!storeLineIds.add(lineReq.getLineId())) {
+                log.warn("InboundSlip store duplicate lineId: slipId={}, lineId={}", id, lineReq.getLineId());
                 throw new BusinessRuleViolationException("DUPLICATE_LINE_IN_REQUEST",
-                        "リクエスト内に同じ明細IDが重複しています (lineId=" + lineReq.getLineId() + ")");
+                        "リクエスト内に同じ明細が重複しています");
             }
         }
 
@@ -406,8 +424,11 @@ public class InboundSlipService {
             InboundSlipLine line = slip.getLines().stream()
                     .filter(l -> l.getId().equals(lineReq.getLineId()))
                     .findFirst()
-                    .orElseThrow(() -> new ResourceNotFoundException("INBOUND_LINE_NOT_FOUND",
-                            "入荷伝票明細が見つかりません (lineId=" + lineReq.getLineId() + ")"));
+                    .orElseThrow(() -> {
+                        log.info("InboundSlip store line not found: slipId={}, lineId={}", id, lineReq.getLineId());
+                        return new ResourceNotFoundException("INBOUND_LINE_NOT_FOUND",
+                                "入荷伝票明細が見つかりません");
+                    });
 
             if (!InboundLineStatus.INSPECTED.getValue().equals(line.getLineStatus())) {
                 throw new InvalidStateTransitionException("INBOUND_LINE_NOT_INSPECTED",

--- a/backend/src/main/java/com/wms/inbound/service/InboundSlipService.java
+++ b/backend/src/main/java/com/wms/inbound/service/InboundSlipService.java
@@ -152,8 +152,9 @@ public class InboundSlipService {
         Set<Long> productIds = new HashSet<>();
         for (CreateInboundLineRequest line : request.getLines()) {
             if (!productIds.add(line.getProductId())) {
+                log.info("InboundSlip create duplicate product in lines: productId={}", line.getProductId());
                 throw new DuplicateResourceException("DUPLICATE_PRODUCT_IN_LINES",
-                        "同一伝票内に同じ商品が複数指定されています (productId=" + line.getProductId() + ")");
+                        "同一伝票内に同じ商品が複数指定されています");
             }
         }
 
@@ -182,19 +183,22 @@ public class InboundSlipService {
             Product product = productService.findById(lineReq.getProductId());
 
             if (!Boolean.TRUE.equals(product.getIsActive())) {
+                log.info("InboundSlip create product inactive: productId={}", product.getId());
                 throw new BusinessRuleViolationException("PRODUCT_INACTIVE",
-                        "無効な商品が指定されています (productId=" + product.getId() + ")");
+                        "無効な商品が指定されています");
             }
 
             if (Boolean.TRUE.equals(product.getLotManageFlag())
                     && (lineReq.getLotNumber() == null || lineReq.getLotNumber().isBlank())) {
+                log.info("InboundSlip create lot number required: productId={}", product.getId());
                 throw new BusinessRuleViolationException("LOT_NUMBER_REQUIRED",
-                        "ロット管理対象商品にはロット番号が必須です (productId=" + product.getId() + ")");
+                        "ロット管理対象商品にはロット番号が必須です");
             }
 
             if (Boolean.TRUE.equals(product.getExpiryManageFlag()) && lineReq.getExpiryDate() == null) {
+                log.info("InboundSlip create expiry date required: productId={}", product.getId());
                 throw new BusinessRuleViolationException("EXPIRY_DATE_REQUIRED",
-                        "期限管理対象商品には賞味/使用期限日が必須です (productId=" + product.getId() + ")");
+                        "期限管理対象商品には賞味/使用期限日が必須です");
             }
 
             return new ProductLineInfo(product, lineReq);
@@ -284,8 +288,9 @@ public class InboundSlipService {
         InboundSlip slip = findByIdWithLines(id);
 
         if (!InboundSlipStatus.PLANNED.getValue().equals(slip.getStatus())) {
+            log.info("InboundSlip confirm rejected due to status: id={}, status={}", id, slip.getStatus());
             throw new InvalidStateTransitionException("INBOUND_INVALID_STATUS",
-                    "PLANNED以外のステータスの入荷伝票は確定できません (status=" + slip.getStatus() + ")");
+                    "現在のステータスでは入荷伝票を確定できません");
         }
 
         slip.setStatus(InboundSlipStatus.CONFIRMED.getValue());
@@ -300,8 +305,9 @@ public class InboundSlipService {
 
         if (InboundSlipStatus.STORED.getValue().equals(slip.getStatus())
                 || InboundSlipStatus.CANCELLED.getValue().equals(slip.getStatus())) {
+            log.info("InboundSlip cancel rejected due to status: id={}, status={}", id, slip.getStatus());
             throw new InvalidStateTransitionException("INBOUND_INVALID_STATUS",
-                    "STOREDまたはCANCELLEDステータスの入荷伝票はキャンセルできません (status=" + slip.getStatus() + ")");
+                    "現在のステータスでは入荷伝票をキャンセルできません");
         }
 
         Long currentUserId = getCurrentUserId();
@@ -337,8 +343,9 @@ public class InboundSlipService {
         if (!InboundSlipStatus.CONFIRMED.getValue().equals(status)
                 && !InboundSlipStatus.INSPECTING.getValue().equals(status)
                 && !InboundSlipStatus.PARTIAL_STORED.getValue().equals(status)) {
+            log.info("InboundSlip inspect rejected due to status: id={}, status={}", id, status);
             throw new InvalidStateTransitionException("INBOUND_INVALID_STATUS",
-                    "検品可能なステータスではありません (status=" + status + ")");
+                    "現在のステータスでは検品できません");
         }
 
         // Duplicate lineId check
@@ -375,8 +382,7 @@ public class InboundSlipService {
                 log.info("InboundSlip inspect negative qty: slipId={}, lineId={}, inspectedQty={}",
                         id, line.getId(), lineReq.getInspectedQty());
                 throw new BusinessRuleViolationException("INBOUND_INSPECTED_QTY_NEGATIVE",
-                        "検品数は0以上である必要があります (inspectedQty="
-                                + lineReq.getInspectedQty() + ")");
+                        "検品数は0以上である必要があります");
             }
 
             line.setInspectedQty(lineReq.getInspectedQty());
@@ -402,8 +408,9 @@ public class InboundSlipService {
         String status = slip.getStatus();
         if (!InboundSlipStatus.INSPECTING.getValue().equals(status)
                 && !InboundSlipStatus.PARTIAL_STORED.getValue().equals(status)) {
+            log.info("InboundSlip store rejected due to status: id={}, status={}", id, status);
             throw new InvalidStateTransitionException("INBOUND_INVALID_STATUS",
-                    "格納可能なステータスではありません (status=" + status + ")");
+                    "現在のステータスでは格納できません");
         }
 
         // Duplicate lineId check
@@ -431,44 +438,54 @@ public class InboundSlipService {
                     });
 
             if (!InboundLineStatus.INSPECTED.getValue().equals(line.getLineStatus())) {
+                log.info("InboundSlip store line not inspected: slipId={}, lineId={}, lineStatus={}",
+                        id, line.getId(), line.getLineStatus());
                 throw new InvalidStateTransitionException("INBOUND_LINE_NOT_INSPECTED",
-                        "検品済みでない明細は格納できません (lineId=" + line.getId() + ", lineStatus=" + line.getLineStatus() + ")");
+                        "検品済みでない明細は格納できません");
             }
 
             if (line.getInspectedQty() == null || line.getInspectedQty() <= 0) {
+                log.info("InboundSlip store inspected qty zero: slipId={}, lineId={}", id, line.getId());
                 throw new BusinessRuleViolationException("INSPECTED_QTY_ZERO",
-                        "検品数が0の明細は格納できません (lineId=" + line.getId() + ")");
+                        "検品数が0の明細は格納できません");
             }
 
             Location location = locationService.findById(lineReq.getLocationId());
 
             if (!location.getWarehouseId().equals(slip.getWarehouseId())) {
+                log.info("InboundSlip store location warehouse mismatch: slipId={}, locationId={}, locationWarehouseId={}, slipWarehouseId={}",
+                        id, location.getId(), location.getWarehouseId(), slip.getWarehouseId());
                 throw new BusinessRuleViolationException("LOCATION_WAREHOUSE_MISMATCH",
-                        "ロケーションが入荷伝票の倉庫に属していません (locationId=" + location.getId()
-                                + ", locationWarehouseId=" + location.getWarehouseId()
-                                + ", slipWarehouseId=" + slip.getWarehouseId() + ")");
+                        "ロケーションが入荷伝票の倉庫に属していません");
             }
 
             if (!Boolean.TRUE.equals(location.getIsActive())) {
+                log.info("InboundSlip store location inactive: slipId={}, locationId={}", id, location.getId());
                 throw new BusinessRuleViolationException("LOCATION_INACTIVE",
-                        "無効なロケーションです (locationId=" + location.getId() + ")");
+                        "無効なロケーションです");
             }
 
             Area area = areaService.findById(location.getAreaId());
 
             if (!"INBOUND".equals(area.getAreaType())) {
+                log.info("InboundSlip store area not inbound: slipId={}, locationId={}, areaType={}",
+                        id, location.getId(), area.getAreaType());
                 throw new BusinessRuleViolationException("AREA_NOT_INBOUND",
-                        "入荷エリア以外のロケーションには格納できません (areaType=" + area.getAreaType() + ")");
+                        "入荷エリア以外のロケーションには格納できません");
             }
 
             if (Boolean.TRUE.equals(location.getIsStocktakingLocked())) {
+                log.info("InboundSlip store location stocktake locked: slipId={}, locationId={}",
+                        id, location.getId());
                 throw new BusinessRuleViolationException("LOCATION_STOCKTAKE_LOCKED",
-                        "棚卸中のロケーションには格納できません (locationId=" + location.getId() + ")");
+                        "棚卸中のロケーションには格納できません");
             }
 
             if (inventoryService.existsDifferentProductAtLocation(location.getId(), line.getProductId())) {
+                log.info("InboundSlip store different product at location: slipId={}, locationId={}, productId={}",
+                        id, location.getId(), line.getProductId());
                 throw new BusinessRuleViolationException("DIFFERENT_PRODUCT_AT_LOCATION",
-                        "同一ロケーションに異なる商品の在庫が存在します (locationId=" + location.getId() + ")");
+                        "同一ロケーションに異なる商品の在庫が存在します");
             }
 
             inventoryService.storeInboundStock(new InventoryService.StoreInboundCommand(
@@ -518,8 +535,9 @@ public class InboundSlipService {
         InboundSlip slip = findByIdWithLines(id);
 
         if (!InboundSlipStatus.PLANNED.getValue().equals(slip.getStatus())) {
+            log.info("InboundSlip delete rejected due to status: id={}, status={}", id, slip.getStatus());
             throw new InvalidStateTransitionException("INBOUND_INVALID_STATUS",
-                    "PLANNED以外のステータスの入荷伝票は削除できません (status=" + slip.getStatus() + ")");
+                    "現在のステータスでは入荷伝票を削除できません");
         }
 
         // CascadeType.ALL + orphanRemoval handles line deletion

--- a/backend/src/main/java/com/wms/inventory/service/InventoryService.java
+++ b/backend/src/main/java/com/wms/inventory/service/InventoryService.java
@@ -106,16 +106,21 @@ public class InventoryService {
                     inventory = inventoryRepository
                             .findByLocationIdAndProductIdAndUnitTypeAndLotNumberAndExpiryDate(
                                     cmd.locationId(), cmd.productId(), cmd.unitType(), cmd.lotNumber(), cmd.expiryDate())
-                            .orElseThrow(() -> new ResourceNotFoundException("INVENTORY_NOT_FOUND",
-                                    "在庫が見つかりません (locationId=" + cmd.locationId() + ", productId=" + cmd.productId() + ")"));
+                            .orElseThrow(() -> {
+                                log.info("Inventory not found after collision retry: locationId={}, productId={}",
+                                        cmd.locationId(), cmd.productId());
+                                return new ResourceNotFoundException("INVENTORY_NOT_FOUND",
+                                        "在庫が見つかりません");
+                            });
                     newQty = inventory.getQuantity() + cmd.quantity();
                     inventory.setQuantity(newQty);
                     inventoryRepository.save(inventory);
                 }
             }
         } catch (ObjectOptimisticLockingFailureException e) {
-            throw new OptimisticLockConflictException("OPTIMISTIC_LOCK_CONFLICT",
-                    "在庫の並行更新が検出されました (locationId=" + cmd.locationId() + ", productId=" + cmd.productId() + ")");
+            log.warn("Inventory optimistic lock conflict on storeInbound: locationId={}, productId={}",
+                    cmd.locationId(), cmd.productId());
+            throw OptimisticLockConflictException.standard();
         }
 
         InventoryMovement movement = InventoryMovement.builder()
@@ -151,28 +156,33 @@ public class InventoryService {
         Inventory inventory = inventoryRepository
                 .findByLocationIdAndProductIdAndUnitTypeAndLotNumberAndExpiryDate(
                         cmd.locationId(), cmd.productId(), cmd.unitType(), cmd.lotNumber(), cmd.expiryDate())
-                .orElseThrow(() -> new ResourceNotFoundException("INVENTORY_NOT_FOUND",
-                        "在庫が見つかりません (locationId=" + cmd.locationId() + ", productId=" + cmd.productId() + ")"));
+                .orElseThrow(() -> {
+                    log.info("Inventory not found on rollback: locationId={}, productId={}",
+                            cmd.locationId(), cmd.productId());
+                    return new ResourceNotFoundException("INVENTORY_NOT_FOUND",
+                            "在庫が見つかりません");
+                });
 
         int newQty = inventory.getQuantity() - cmd.quantity();
         if (newQty < 0) {
+            log.warn("Inventory rollback would make quantity negative: inventoryId={}, quantity={}, rollback={}",
+                    inventory.getId(), inventory.getQuantity(), cmd.quantity());
             throw new BusinessRuleViolationException("INVENTORY_INSUFFICIENT",
-                    "在庫ロールバックで在庫数が負になります (inventoryId=" + inventory.getId()
-                            + ", quantity=" + inventory.getQuantity()
-                            + ", rollback=" + cmd.quantity() + ")");
+                    "在庫ロールバックで在庫数が負になります");
         }
         if (newQty < inventory.getAllocatedQty()) {
+            log.warn("Inventory rollback would exceed allocated: inventoryId={}, allocatedQty={}, newQuantity={}",
+                    inventory.getId(), inventory.getAllocatedQty(), newQty);
             throw new BusinessRuleViolationException("INVENTORY_ALLOCATED",
-                    "引当済み数量が在庫ロールバック後の数量を超えます (inventoryId=" + inventory.getId()
-                            + ", allocatedQty=" + inventory.getAllocatedQty()
-                            + ", newQuantity=" + newQty + ")");
+                    "引当済み数量が在庫ロールバック後の数量を超えます");
         }
         inventory.setQuantity(newQty);
         try {
             inventoryRepository.save(inventory);
         } catch (ObjectOptimisticLockingFailureException e) {
-            throw new OptimisticLockConflictException("OPTIMISTIC_LOCK_CONFLICT",
-                    "在庫の並行更新が検出されました (locationId=" + cmd.locationId() + ", productId=" + cmd.productId() + ")");
+            log.warn("Inventory optimistic lock conflict on rollback: locationId={}, productId={}",
+                    cmd.locationId(), cmd.productId());
+            throw OptimisticLockConflictException.standard();
         }
 
         InventoryMovement movement = InventoryMovement.builder()
@@ -216,8 +226,10 @@ public class InventoryService {
                         cmd.locationId(), cmd.productId(), cmd.unitType());
 
         if (inventories.isEmpty()) {
+            log.info("Inventory not found on return deduction: locationId={}, productId={}",
+                    cmd.locationId(), cmd.productId());
             throw new ResourceNotFoundException("INVENTORY_NOT_FOUND",
-                    "在庫が見つかりません (locationId=" + cmd.locationId() + ", productId=" + cmd.productId() + ")");
+                    "在庫が見つかりません");
         }
 
         boolean hasAllocated = inventories.stream().anyMatch(i -> i.getAllocatedQty() > 0);
@@ -229,8 +241,10 @@ public class InventoryService {
         int totalAvailable = inventories.stream()
                 .mapToInt(i -> i.getQuantity() - i.getAllocatedQty()).sum();
         if (cmd.quantity() > totalAvailable) {
+            log.warn("Return quantity exceeds available stock: locationId={}, productId={}, available={}, requested={}",
+                    cmd.locationId(), cmd.productId(), totalAvailable, cmd.quantity());
             throw new BusinessRuleViolationException("RETURN_INSUFFICIENT_QUANTITY",
-                    "返品数量が在庫数を超えています (available=" + totalAvailable + ", requested=" + cmd.quantity() + ")");
+                    "返品数量が在庫数を超えています");
         }
 
         // 複数在庫レコード（ロット違い等）に対してID順に分散減算する
@@ -248,8 +262,9 @@ public class InventoryService {
             try {
                 inventoryRepository.save(inventory);
             } catch (ObjectOptimisticLockingFailureException e) {
-                throw new OptimisticLockConflictException("OPTIMISTIC_LOCK_CONFLICT",
-                        "在庫の並行更新が検出されました (locationId=" + cmd.locationId() + ", productId=" + cmd.productId() + ")");
+                log.warn("Inventory optimistic lock conflict on return deduction: locationId={}, productId={}, inventoryId={}",
+                        cmd.locationId(), cmd.productId(), inventory.getId());
+                throw OptimisticLockConflictException.standard();
             }
 
             InventoryMovement movement = InventoryMovement.builder()

--- a/backend/src/main/java/com/wms/inventory/service/StocktakeQueryService.java
+++ b/backend/src/main/java/com/wms/inventory/service/StocktakeQueryService.java
@@ -54,15 +54,22 @@ public class StocktakeQueryService {
     }
 
     public StocktakeHeader findById(Long id) {
+        // SEC-R2-Min-1 (OWASP A09): 例外メッセージには内部 id を含めない。追跡用 id は log 側に出力する。
         return stocktakeHeaderRepository.findById(id)
-                .orElseThrow(() -> new ResourceNotFoundException(
-                        "STOCKTAKE_NOT_FOUND", "棚卸が見つかりません (id=" + id + ")"));
+                .orElseThrow(() -> {
+                    log.info("Stocktake not found: id={}", id);
+                    return new ResourceNotFoundException(
+                            "STOCKTAKE_NOT_FOUND", "棚卸が見つかりません");
+                });
     }
 
     public StocktakeHeader findByIdWithLines(Long id) {
         return stocktakeHeaderRepository.findByIdWithLines(id)
-                .orElseThrow(() -> new ResourceNotFoundException(
-                        "STOCKTAKE_NOT_FOUND", "棚卸が見つかりません (id=" + id + ")"));
+                .orElseThrow(() -> {
+                    log.info("Stocktake not found (withLines): id={}", id);
+                    return new ResourceNotFoundException(
+                            "STOCKTAKE_NOT_FOUND", "棚卸が見つかりません");
+                });
     }
 
     public long countTotalLines(Long headerId) {

--- a/backend/src/main/java/com/wms/inventory/service/StocktakeService.java
+++ b/backend/src/main/java/com/wms/inventory/service/StocktakeService.java
@@ -183,8 +183,9 @@ public class StocktakeService {
                 });
 
         if (!"STARTED".equals(header.getStatus())) {
+            log.info("Stocktake rejected due to status: headerId={}, status={}", headerId, header.getStatus());
             throw new com.wms.shared.exception.InvalidStateTransitionException("STOCKTAKE_INVALID_STATUS",
-                    "棚卸が実施中ではありません (status=" + header.getStatus() + ")");
+                    "棚卸が実施中ではありません");
         }
 
         Long userId = getCurrentUserId();
@@ -208,7 +209,7 @@ public class StocktakeService {
                 log.warn("Stocktake line belongs to different header: headerId={}, lineId={}, actualHeaderId={}",
                         headerId, input.lineId(), line.getStocktakeHeader().getId());
                 throw new ResourceNotFoundException("STOCKTAKE_LINE_NOT_FOUND",
-                        "棚卸明細が指定棚卸に属していません");
+                        "棚卸明細が見つかりません");
             }
 
             line.setQuantityCounted(input.actualQty());
@@ -245,8 +246,9 @@ public class StocktakeService {
                 });
 
         if (!"STARTED".equals(header.getStatus())) {
+            log.info("Stocktake rejected due to status: headerId={}, status={}", headerId, header.getStatus());
             throw new com.wms.shared.exception.InvalidStateTransitionException("STOCKTAKE_INVALID_STATUS",
-                    "棚卸が実施中ではありません (status=" + header.getStatus() + ")");
+                    "棚卸が実施中ではありません");
         }
 
         // 全明細入力済みチェック

--- a/backend/src/main/java/com/wms/inventory/service/StocktakeService.java
+++ b/backend/src/main/java/com/wms/inventory/service/StocktakeService.java
@@ -174,9 +174,13 @@ public class StocktakeService {
             throw new BusinessRuleViolationException("STOCKTAKE_LINES_REQUIRED", "明細を1件以上指定してください");
         }
 
+        // SEC-R2-Min-1 (OWASP A09): 例外メッセージには内部 id を含めない。追跡用 id は log 側に出力する。
         StocktakeHeader header = stocktakeHeaderRepository.findById(headerId)
-                .orElseThrow(() -> new ResourceNotFoundException("STOCKTAKE_NOT_FOUND",
-                        "棚卸が見つかりません (id=" + headerId + ")"));
+                .orElseThrow(() -> {
+                    log.info("Stocktake header not found: id={}", headerId);
+                    return new ResourceNotFoundException("STOCKTAKE_NOT_FOUND",
+                            "棚卸が見つかりません");
+                });
 
         if (!"STARTED".equals(header.getStatus())) {
             throw new com.wms.shared.exception.InvalidStateTransitionException("STOCKTAKE_INVALID_STATUS",
@@ -194,12 +198,17 @@ public class StocktakeService {
             }
 
             com.wms.inventory.entity.StocktakeLine line = stocktakeLineRepository.findById(input.lineId())
-                    .orElseThrow(() -> new ResourceNotFoundException("STOCKTAKE_LINE_NOT_FOUND",
-                            "棚卸明細が見つかりません (lineId=" + input.lineId() + ")"));
+                    .orElseThrow(() -> {
+                        log.info("Stocktake line not found: headerId={}, lineId={}", headerId, input.lineId());
+                        return new ResourceNotFoundException("STOCKTAKE_LINE_NOT_FOUND",
+                                "棚卸明細が見つかりません");
+                    });
 
             if (!line.getStocktakeHeader().getId().equals(headerId)) {
+                log.warn("Stocktake line belongs to different header: headerId={}, lineId={}, actualHeaderId={}",
+                        headerId, input.lineId(), line.getStocktakeHeader().getId());
                 throw new ResourceNotFoundException("STOCKTAKE_LINE_NOT_FOUND",
-                        "棚卸明細が指定棚卸に属していません (lineId=" + input.lineId() + ")");
+                        "棚卸明細が指定棚卸に属していません");
             }
 
             line.setQuantityCounted(input.actualQty());
@@ -229,8 +238,11 @@ public class StocktakeService {
     @Transactional
     public ConfirmResult confirmStocktake(Long headerId) {
         StocktakeHeader header = stocktakeHeaderRepository.findByIdWithLines(headerId)
-                .orElseThrow(() -> new ResourceNotFoundException("STOCKTAKE_NOT_FOUND",
-                        "棚卸が見つかりません (id=" + headerId + ")"));
+                .orElseThrow(() -> {
+                    log.info("Stocktake header not found (withLines): id={}", headerId);
+                    return new ResourceNotFoundException("STOCKTAKE_NOT_FOUND",
+                            "棚卸が見つかりません");
+                });
 
         if (!"STARTED".equals(header.getStatus())) {
             throw new com.wms.shared.exception.InvalidStateTransitionException("STOCKTAKE_INVALID_STATUS",

--- a/backend/src/main/java/com/wms/master/service/AreaService.java
+++ b/backend/src/main/java/com/wms/master/service/AreaService.java
@@ -72,8 +72,9 @@ public class AreaService {
     public Area update(Long id, String areaName, String storageCondition, Integer version) {
         Area area = findById(id);
         if (!area.getVersion().equals(version)) {
-            throw new OptimisticLockConflictException("OPTIMISTIC_LOCK_CONFLICT",
-                    "他のユーザーによる更新が先行しました (id=" + id + ")");
+            log.info("Area update version mismatch: id={}, expected={}, actual={}",
+                    id, version, area.getVersion());
+            throw optimisticLockConflict();
         }
         area.setAreaName(areaName);
         area.setStorageCondition(storageCondition);
@@ -83,8 +84,8 @@ public class AreaService {
             log.info("Area updated: id={}, name={}", id, areaName);
             return saved;
         } catch (ObjectOptimisticLockingFailureException e) {
-            throw new OptimisticLockConflictException("OPTIMISTIC_LOCK_CONFLICT",
-                    "他のユーザーによる更新が先行しました (id=" + id + ")");
+            log.info("Area update OL conflict detected at commit: id={}", id);
+            throw optimisticLockConflict();
         }
     }
 
@@ -92,12 +93,15 @@ public class AreaService {
     public Area toggleActive(Long id, boolean isActive, Integer version) {
         Area area = findById(id);
         if (!area.getVersion().equals(version)) {
-            throw new OptimisticLockConflictException("OPTIMISTIC_LOCK_CONFLICT",
-                    "他のユーザーによる更新が先行しました (id=" + id + ")");
+            log.info("Area toggleActive version mismatch: id={}, expected={}, actual={}",
+                    id, version, area.getVersion());
+            throw optimisticLockConflict();
         }
         if (!isActive && locationRepository.countByAreaIdAndIsActiveTrue(id) > 0) {
+            // OWASP A09: 例外メッセージには内部 id を含めない。id は log 側に出力。
+            log.info("Area deactivate blocked by active children locations: id={}", id);
             throw new BusinessRuleViolationException("CANNOT_DEACTIVATE_HAS_CHILDREN",
-                    "配下に有効なロケーションが存在するため無効化できません (id=" + id + ")");
+                    "配下に有効なロケーションが存在するため無効化できません");
         }
         if (area.getIsActive().equals(isActive)) {
             log.info("Area toggleActive no-op: id={}, isActive={}", id, isActive);
@@ -114,8 +118,15 @@ public class AreaService {
             log.info("Area toggled: id={}, isActive={}", id, isActive);
             return saved;
         } catch (ObjectOptimisticLockingFailureException e) {
-            throw new OptimisticLockConflictException("OPTIMISTIC_LOCK_CONFLICT",
-                    "他のユーザーによる更新が先行しました (id=" + id + ")");
+            log.info("Area toggleActive OL conflict detected at commit: id={}", id);
+            throw optimisticLockConflict();
         }
+    }
+
+    private OptimisticLockConflictException optimisticLockConflict() {
+        // OWASP A09: 例外メッセージには内部 id を含めない。id は log 側に出力する。
+        return new OptimisticLockConflictException(
+                "OPTIMISTIC_LOCK_CONFLICT",
+                "他のユーザーによる更新が先行しました");
     }
 }

--- a/backend/src/main/java/com/wms/master/service/AreaService.java
+++ b/backend/src/main/java/com/wms/master/service/AreaService.java
@@ -122,5 +122,4 @@ public class AreaService {
             throw OptimisticLockConflictException.standard();
         }
     }
-
 }

--- a/backend/src/main/java/com/wms/master/service/AreaService.java
+++ b/backend/src/main/java/com/wms/master/service/AreaService.java
@@ -74,7 +74,7 @@ public class AreaService {
         if (!area.getVersion().equals(version)) {
             log.info("Area update version mismatch: id={}, expected={}, actual={}",
                     id, version, area.getVersion());
-            throw optimisticLockConflict();
+            throw OptimisticLockConflictException.standard();
         }
         area.setAreaName(areaName);
         area.setStorageCondition(storageCondition);
@@ -85,7 +85,7 @@ public class AreaService {
             return saved;
         } catch (ObjectOptimisticLockingFailureException e) {
             log.info("Area update OL conflict detected at commit: id={}", id);
-            throw optimisticLockConflict();
+            throw OptimisticLockConflictException.standard();
         }
     }
 
@@ -95,7 +95,7 @@ public class AreaService {
         if (!area.getVersion().equals(version)) {
             log.info("Area toggleActive version mismatch: id={}, expected={}, actual={}",
                     id, version, area.getVersion());
-            throw optimisticLockConflict();
+            throw OptimisticLockConflictException.standard();
         }
         if (!isActive && locationRepository.countByAreaIdAndIsActiveTrue(id) > 0) {
             // OWASP A09: 例外メッセージには内部 id を含めない。id は log 側に出力。
@@ -119,14 +119,8 @@ public class AreaService {
             return saved;
         } catch (ObjectOptimisticLockingFailureException e) {
             log.info("Area toggleActive OL conflict detected at commit: id={}", id);
-            throw optimisticLockConflict();
+            throw OptimisticLockConflictException.standard();
         }
     }
 
-    private OptimisticLockConflictException optimisticLockConflict() {
-        // OWASP A09: 例外メッセージには内部 id を含めない。id は log 側に出力する。
-        return new OptimisticLockConflictException(
-                "OPTIMISTIC_LOCK_CONFLICT",
-                "他のユーザーによる更新が先行しました");
-    }
 }

--- a/backend/src/main/java/com/wms/master/service/BuildingService.java
+++ b/backend/src/main/java/com/wms/master/service/BuildingService.java
@@ -68,7 +68,7 @@ public class BuildingService {
         if (!building.getVersion().equals(version)) {
             log.info("Building update version mismatch: id={}, expected={}, actual={}",
                     id, version, building.getVersion());
-            throw optimisticLockConflict();
+            throw OptimisticLockConflictException.standard();
         }
         building.setBuildingName(buildingName);
         building.setVersion(version);
@@ -78,7 +78,7 @@ public class BuildingService {
             return saved;
         } catch (ObjectOptimisticLockingFailureException e) {
             log.info("Building update OL conflict detected at commit: id={}", id);
-            throw optimisticLockConflict();
+            throw OptimisticLockConflictException.standard();
         }
     }
 
@@ -88,7 +88,7 @@ public class BuildingService {
         if (!building.getVersion().equals(version)) {
             log.info("Building toggleActive version mismatch: id={}, expected={}, actual={}",
                     id, version, building.getVersion());
-            throw optimisticLockConflict();
+            throw OptimisticLockConflictException.standard();
         }
         if (!isActive && areaRepository.countByBuildingId(id) > 0) {
             // OWASP A09: 例外メッセージには内部 id を含めない。id は log 側に出力。
@@ -112,15 +112,8 @@ public class BuildingService {
             return saved;
         } catch (ObjectOptimisticLockingFailureException e) {
             log.info("Building toggleActive OL conflict detected at commit: id={}", id);
-            throw optimisticLockConflict();
+            throw OptimisticLockConflictException.standard();
         }
-    }
-
-    private OptimisticLockConflictException optimisticLockConflict() {
-        // OWASP A09: 例外メッセージには内部 id を含めない。id は log 側に出力する。
-        return new OptimisticLockConflictException(
-                "OPTIMISTIC_LOCK_CONFLICT",
-                "他のユーザーによる更新が先行しました");
     }
 
     public boolean existsByWarehouseIdAndCode(Long warehouseId, String code) {

--- a/backend/src/main/java/com/wms/master/service/BuildingService.java
+++ b/backend/src/main/java/com/wms/master/service/BuildingService.java
@@ -66,8 +66,9 @@ public class BuildingService {
     public Building update(Long id, String buildingName, Integer version) {
         Building building = findById(id);
         if (!building.getVersion().equals(version)) {
-            throw new OptimisticLockConflictException("OPTIMISTIC_LOCK_CONFLICT",
-                    "他のユーザーによる更新が先行しました (id=" + id + ")");
+            log.info("Building update version mismatch: id={}, expected={}, actual={}",
+                    id, version, building.getVersion());
+            throw optimisticLockConflict();
         }
         building.setBuildingName(buildingName);
         building.setVersion(version);
@@ -76,8 +77,8 @@ public class BuildingService {
             log.info("Building updated: id={}, name={}", id, buildingName);
             return saved;
         } catch (ObjectOptimisticLockingFailureException e) {
-            throw new OptimisticLockConflictException("OPTIMISTIC_LOCK_CONFLICT",
-                    "他のユーザーによる更新が先行しました (id=" + id + ")");
+            log.info("Building update OL conflict detected at commit: id={}", id);
+            throw optimisticLockConflict();
         }
     }
 
@@ -85,12 +86,15 @@ public class BuildingService {
     public Building toggleActive(Long id, boolean isActive, Integer version) {
         Building building = findById(id);
         if (!building.getVersion().equals(version)) {
-            throw new OptimisticLockConflictException("OPTIMISTIC_LOCK_CONFLICT",
-                    "他のユーザーによる更新が先行しました (id=" + id + ")");
+            log.info("Building toggleActive version mismatch: id={}, expected={}, actual={}",
+                    id, version, building.getVersion());
+            throw optimisticLockConflict();
         }
         if (!isActive && areaRepository.countByBuildingId(id) > 0) {
+            // OWASP A09: 例外メッセージには内部 id を含めない。id は log 側に出力。
+            log.info("Building deactivate blocked by children areas: id={}", id);
             throw new BusinessRuleViolationException("CANNOT_DEACTIVATE_HAS_CHILDREN",
-                    "配下にエリアが存在するため無効化できません (id=" + id + ")");
+                    "配下にエリアが存在するため無効化できません");
         }
         if (building.getIsActive().equals(isActive)) {
             log.info("Building toggleActive no-op: id={}, isActive={}", id, isActive);
@@ -107,9 +111,16 @@ public class BuildingService {
             log.info("Building toggled: id={}, isActive={}", id, isActive);
             return saved;
         } catch (ObjectOptimisticLockingFailureException e) {
-            throw new OptimisticLockConflictException("OPTIMISTIC_LOCK_CONFLICT",
-                    "他のユーザーによる更新が先行しました (id=" + id + ")");
+            log.info("Building toggleActive OL conflict detected at commit: id={}", id);
+            throw optimisticLockConflict();
         }
+    }
+
+    private OptimisticLockConflictException optimisticLockConflict() {
+        // OWASP A09: 例外メッセージには内部 id を含めない。id は log 側に出力する。
+        return new OptimisticLockConflictException(
+                "OPTIMISTIC_LOCK_CONFLICT",
+                "他のユーザーによる更新が先行しました");
     }
 
     public boolean existsByWarehouseIdAndCode(Long warehouseId, String code) {

--- a/backend/src/main/java/com/wms/master/service/LocationService.java
+++ b/backend/src/main/java/com/wms/master/service/LocationService.java
@@ -105,7 +105,7 @@ public class LocationService {
         if (!location.getVersion().equals(version)) {
             log.info("Location update version mismatch: id={}, expected={}, actual={}",
                     id, version, location.getVersion());
-            throw optimisticLockConflict();
+            throw OptimisticLockConflictException.standard();
         }
         location.setLocationName(locationName);
         location.setVersion(version);
@@ -115,7 +115,7 @@ public class LocationService {
             return saved;
         } catch (ObjectOptimisticLockingFailureException e) {
             log.info("Location update OL conflict detected at commit: id={}", id);
-            throw optimisticLockConflict();
+            throw OptimisticLockConflictException.standard();
         }
     }
 
@@ -125,7 +125,7 @@ public class LocationService {
         if (!location.getVersion().equals(version)) {
             log.info("Location toggleActive version mismatch: id={}, expected={}, actual={}",
                     id, version, location.getVersion());
-            throw optimisticLockConflict();
+            throw OptimisticLockConflictException.standard();
         }
         // 冪等性のため、状態が実際に変化しない場合は早期 return（後続の在庫チェックも省略）
         if (location.getIsActive().equals(isActive)) {
@@ -162,15 +162,8 @@ public class LocationService {
             return saved;
         } catch (ObjectOptimisticLockingFailureException e) {
             log.info("Location toggleActive OL conflict detected at commit: id={}", id);
-            throw optimisticLockConflict();
+            throw OptimisticLockConflictException.standard();
         }
     }
 
-    private OptimisticLockConflictException optimisticLockConflict() {
-        // OWASP A09: 例外メッセージには内部 id を含めない (ID 列挙への補助情報を与えない)。
-        // 追跡用の id はログ側 (呼び出し元の log.info) に出力する。
-        return new OptimisticLockConflictException(
-                "OPTIMISTIC_LOCK_CONFLICT",
-                "他のユーザーによる更新が先行しました");
-    }
 }

--- a/backend/src/main/java/com/wms/master/service/LocationService.java
+++ b/backend/src/main/java/com/wms/master/service/LocationService.java
@@ -165,5 +165,4 @@ public class LocationService {
             throw OptimisticLockConflictException.standard();
         }
     }
-
 }

--- a/backend/src/main/java/com/wms/master/service/LocationService.java
+++ b/backend/src/main/java/com/wms/master/service/LocationService.java
@@ -77,8 +77,11 @@ public class LocationService {
         // INBOUND/OUTBOUND/RETURN エリアはロケーション 1 件限定
         if (!area.getAreaType().equals("STOCK")
                 && locationRepository.countByAreaId(area.getId()) >= SINGLE_LOCATION_AREA_LIMIT) {
+            // OWASP A09: 例外メッセージには内部 id を含めない。追跡用の areaId は log 側に出力。
+            log.info("Location create blocked by area limit: areaId={}, areaType={}",
+                    area.getId(), area.getAreaType());
             throw new BusinessRuleViolationException("AREA_LOCATION_LIMIT_EXCEEDED",
-                    area.getAreaType() + " エリアにはロケーションを1件のみ登録できます (areaId=" + area.getId() + ")");
+                    area.getAreaType() + " エリアにはロケーションを1件のみ登録できます");
         }
 
         if (locationRepository.existsByWarehouseIdAndLocationCode(
@@ -100,8 +103,9 @@ public class LocationService {
     public Location update(Long id, String locationName, Integer version) {
         Location location = findById(id);
         if (!location.getVersion().equals(version)) {
-            throw new OptimisticLockConflictException("OPTIMISTIC_LOCK_CONFLICT",
-                    "他のユーザーによる更新が先行しました (id=" + id + ")");
+            log.info("Location update version mismatch: id={}, expected={}, actual={}",
+                    id, version, location.getVersion());
+            throw optimisticLockConflict();
         }
         location.setLocationName(locationName);
         location.setVersion(version);
@@ -110,8 +114,8 @@ public class LocationService {
             log.info("Location updated: id={}, name={}", id, locationName);
             return saved;
         } catch (ObjectOptimisticLockingFailureException e) {
-            throw new OptimisticLockConflictException("OPTIMISTIC_LOCK_CONFLICT",
-                    "他のユーザーによる更新が先行しました (id=" + id + ")");
+            log.info("Location update OL conflict detected at commit: id={}", id);
+            throw optimisticLockConflict();
         }
     }
 
@@ -119,8 +123,9 @@ public class LocationService {
     public Location toggleActive(Long id, boolean isActive, Integer version) {
         Location location = findById(id);
         if (!location.getVersion().equals(version)) {
-            throw new OptimisticLockConflictException("OPTIMISTIC_LOCK_CONFLICT",
-                    "他のユーザーによる更新が先行しました (id=" + id + ")");
+            log.info("Location toggleActive version mismatch: id={}, expected={}, actual={}",
+                    id, version, location.getVersion());
+            throw optimisticLockConflict();
         }
         // 冪等性のため、状態が実際に変化しない場合は早期 return（後続の在庫チェックも省略）
         if (location.getIsActive().equals(isActive)) {
@@ -132,15 +137,18 @@ public class LocationService {
         // (上の no-op 判定により、状態が実際に変化する場合のみここに到達する)
         // 無効化時: 在庫が存在するロケーションは無効化不可 (BR: CANNOT_DEACTIVATE_HAS_INVENTORY)
         if (!isActive && inventoryService.hasInventoryByLocationId(id)) {
+            // OWASP A09: 例外メッセージには内部 id を含めない。id は log 側に出力。
+            log.info("Location deactivate blocked by inventory: id={}", id);
             throw new BusinessRuleViolationException(
                     "CANNOT_DEACTIVATE_HAS_INVENTORY",
-                    "在庫が存在するため無効化できません (id=" + id + ")");
+                    "在庫が存在するため無効化できません");
         }
         // 無効化時: 棚卸中のロケーションは無効化不可 (BR: CANNOT_DEACTIVATE_STOCKTAKE_IN_PROGRESS)
         if (!isActive && location.getIsStocktakingLocked()) {
+            log.info("Location deactivate blocked by stocktake lock: id={}", id);
             throw new BusinessRuleViolationException(
                     "CANNOT_DEACTIVATE_STOCKTAKE_IN_PROGRESS",
-                    "棚卸中のため無効化できません (id=" + id + ")");
+                    "棚卸中のため無効化できません");
         }
         if (isActive) {
             location.activate();
@@ -153,8 +161,16 @@ public class LocationService {
             log.info("Location toggled: id={}, isActive={}", id, isActive);
             return saved;
         } catch (ObjectOptimisticLockingFailureException e) {
-            throw new OptimisticLockConflictException("OPTIMISTIC_LOCK_CONFLICT",
-                    "他のユーザーによる更新が先行しました (id=" + id + ")");
+            log.info("Location toggleActive OL conflict detected at commit: id={}", id);
+            throw optimisticLockConflict();
         }
+    }
+
+    private OptimisticLockConflictException optimisticLockConflict() {
+        // OWASP A09: 例外メッセージには内部 id を含めない (ID 列挙への補助情報を与えない)。
+        // 追跡用の id はログ側 (呼び出し元の log.info) に出力する。
+        return new OptimisticLockConflictException(
+                "OPTIMISTIC_LOCK_CONFLICT",
+                "他のユーザーによる更新が先行しました");
     }
 }

--- a/backend/src/main/java/com/wms/master/service/PartnerService.java
+++ b/backend/src/main/java/com/wms/master/service/PartnerService.java
@@ -76,7 +76,7 @@ public class PartnerService {
         if (!Objects.equals(partner.getVersion(), cmd.version())) {
             log.info("Partner update version mismatch: id={}, expected={}, actual={}",
                     cmd.id(), cmd.version(), partner.getVersion());
-            throw optimisticLockConflict();
+            throw OptimisticLockConflictException.standard();
         }
         partner.setPartnerName(cmd.partnerName());
         partner.setPartnerNameKana(cmd.partnerNameKana());
@@ -93,7 +93,7 @@ public class PartnerService {
         } catch (ObjectOptimisticLockingFailureException e) {
             // version は事前チェック済みだが、load → commit 間の短窓競合に対する二重防御として catch も残置
             log.info("Partner update OL conflict detected at commit: id={}", cmd.id());
-            throw optimisticLockConflict();
+            throw OptimisticLockConflictException.standard();
         }
     }
 
@@ -106,7 +106,7 @@ public class PartnerService {
         if (!Objects.equals(partner.getVersion(), version)) {
             log.info("Partner toggleActive version mismatch: id={}, expected={}, actual={}",
                     id, version, partner.getVersion());
-            throw optimisticLockConflict();
+            throw OptimisticLockConflictException.standard();
         }
         if (Objects.equals(partner.getIsActive(), isActive)) {
             log.info("Partner toggleActive no-op: id={}, isActive={}", id, isActive);
@@ -150,16 +150,8 @@ public class PartnerService {
             return saved;
         } catch (ObjectOptimisticLockingFailureException e) {
             log.info("Partner toggleActive OL conflict detected at commit: id={}", id);
-            throw optimisticLockConflict();
+            throw OptimisticLockConflictException.standard();
         }
-    }
-
-    private OptimisticLockConflictException optimisticLockConflict() {
-        // OWASP A09: 例外メッセージには内部 id を含めない (ID 列挙への補助情報を与えない)。
-        // 追跡用の id はログ側 (呼び出し元の log.info/warn) に出力する。
-        return new OptimisticLockConflictException(
-                "OPTIMISTIC_LOCK_CONFLICT",
-                "他のユーザーによる更新が先行しました");
     }
 
     public boolean existsByCode(String partnerCode) {

--- a/backend/src/main/java/com/wms/master/service/ProductService.java
+++ b/backend/src/main/java/com/wms/master/service/ProductService.java
@@ -89,20 +89,23 @@ public class ProductService {
         Product product = findById(cmd.id());
 
         if (!product.getVersion().equals(cmd.version())) {
-            throw new OptimisticLockConflictException(
-                    "OPTIMISTIC_LOCK_CONFLICT",
-                    "他のユーザーによる更新が先行しました (id=" + cmd.id() + ")");
+            log.info("Product update version mismatch: id={}, expected={}, actual={}",
+                    cmd.id(), cmd.version(), product.getVersion());
+            throw optimisticLockConflict();
         }
 
         boolean lotFlagChanged = !product.getLotManageFlag().equals(cmd.lotManageFlag());
         boolean expiryFlagChanged = !product.getExpiryManageFlag().equals(cmd.expiryManageFlag());
         if ((lotFlagChanged || expiryFlagChanged) && inventoryService.hasInventoryByProductId(cmd.id())) {
             if (lotFlagChanged) {
+                // OWASP A09: 例外メッセージには内部 id を含めない。id は log 側に出力。
+                log.info("Product lot manage flag change blocked by inventory: id={}", cmd.id());
                 throw new BusinessRuleViolationException("CANNOT_CHANGE_LOT_MANAGE_FLAG",
-                        "在庫が存在するためロット管理フラグを変更できません (id=" + cmd.id() + ")");
+                        "在庫が存在するためロット管理フラグを変更できません");
             }
+            log.info("Product expiry manage flag change blocked by inventory: id={}", cmd.id());
             throw new BusinessRuleViolationException("CANNOT_CHANGE_EXPIRY_MANAGE_FLAG",
-                    "在庫が存在するため期限管理フラグを変更できません (id=" + cmd.id() + ")");
+                    "在庫が存在するため期限管理フラグを変更できません");
         }
 
         product.setProductName(cmd.productName());
@@ -126,9 +129,8 @@ public class ProductService {
             log.info("Product updated: id={}, name={}", cmd.id(), cmd.productName());
             return saved;
         } catch (ObjectOptimisticLockingFailureException e) {
-            throw new OptimisticLockConflictException(
-                    "OPTIMISTIC_LOCK_CONFLICT",
-                    "他のユーザーによる更新が先行しました (id=" + cmd.id() + ")");
+            log.info("Product update OL conflict detected at commit: id={}", cmd.id());
+            throw optimisticLockConflict();
         }
     }
 
@@ -137,14 +139,16 @@ public class ProductService {
         Product product = findById(id);
 
         if (!product.getVersion().equals(version)) {
-            throw new OptimisticLockConflictException(
-                    "OPTIMISTIC_LOCK_CONFLICT",
-                    "他のユーザーによる更新が先行しました (id=" + id + ")");
+            log.info("Product toggleActive version mismatch: id={}, expected={}, actual={}",
+                    id, version, product.getVersion());
+            throw optimisticLockConflict();
         }
 
         if (!isActive && inventoryService.hasInventoryByProductId(id)) {
+            // OWASP A09: 例外メッセージには内部 id を含めない。id は log 側に出力。
+            log.info("Product deactivate blocked by inventory: id={}", id);
             throw new BusinessRuleViolationException("CANNOT_DEACTIVATE_HAS_INVENTORY",
-                    "在庫が存在するため商品を無効化できません (id=" + id + ")");
+                    "在庫が存在するため商品を無効化できません");
         }
         if (product.getIsActive().equals(isActive)) {
             log.info("Product toggleActive no-op: id={}, isActive={}", id, isActive);
@@ -161,10 +165,16 @@ public class ProductService {
             log.info("Product toggled: id={}, isActive={}", id, isActive);
             return saved;
         } catch (ObjectOptimisticLockingFailureException e) {
-            throw new OptimisticLockConflictException(
-                    "OPTIMISTIC_LOCK_CONFLICT",
-                    "他のユーザーによる更新が先行しました (id=" + id + ")");
+            log.info("Product toggleActive OL conflict detected at commit: id={}", id);
+            throw optimisticLockConflict();
         }
+    }
+
+    private OptimisticLockConflictException optimisticLockConflict() {
+        // OWASP A09: 例外メッセージには内部 id を含めない。id は log 側に出力する。
+        return new OptimisticLockConflictException(
+                "OPTIMISTIC_LOCK_CONFLICT",
+                "他のユーザーによる更新が先行しました");
     }
 
     public boolean hasInventory(Long productId) {

--- a/backend/src/main/java/com/wms/master/service/ProductService.java
+++ b/backend/src/main/java/com/wms/master/service/ProductService.java
@@ -91,7 +91,7 @@ public class ProductService {
         if (!product.getVersion().equals(cmd.version())) {
             log.info("Product update version mismatch: id={}, expected={}, actual={}",
                     cmd.id(), cmd.version(), product.getVersion());
-            throw optimisticLockConflict();
+            throw OptimisticLockConflictException.standard();
         }
 
         boolean lotFlagChanged = !product.getLotManageFlag().equals(cmd.lotManageFlag());
@@ -130,7 +130,7 @@ public class ProductService {
             return saved;
         } catch (ObjectOptimisticLockingFailureException e) {
             log.info("Product update OL conflict detected at commit: id={}", cmd.id());
-            throw optimisticLockConflict();
+            throw OptimisticLockConflictException.standard();
         }
     }
 
@@ -141,7 +141,7 @@ public class ProductService {
         if (!product.getVersion().equals(version)) {
             log.info("Product toggleActive version mismatch: id={}, expected={}, actual={}",
                     id, version, product.getVersion());
-            throw optimisticLockConflict();
+            throw OptimisticLockConflictException.standard();
         }
 
         if (!isActive && inventoryService.hasInventoryByProductId(id)) {
@@ -166,15 +166,8 @@ public class ProductService {
             return saved;
         } catch (ObjectOptimisticLockingFailureException e) {
             log.info("Product toggleActive OL conflict detected at commit: id={}", id);
-            throw optimisticLockConflict();
+            throw OptimisticLockConflictException.standard();
         }
-    }
-
-    private OptimisticLockConflictException optimisticLockConflict() {
-        // OWASP A09: 例外メッセージには内部 id を含めない。id は log 側に出力する。
-        return new OptimisticLockConflictException(
-                "OPTIMISTIC_LOCK_CONFLICT",
-                "他のユーザーによる更新が先行しました");
     }
 
     public boolean hasInventory(Long productId) {

--- a/backend/src/main/java/com/wms/master/service/WarehouseService.java
+++ b/backend/src/main/java/com/wms/master/service/WarehouseService.java
@@ -81,7 +81,7 @@ public class WarehouseService {
         if (!warehouse.getVersion().equals(version)) {
             log.info("Warehouse update version mismatch: id={}, expected={}, actual={}",
                     id, version, warehouse.getVersion());
-            throw optimisticLockConflict();
+            throw OptimisticLockConflictException.standard();
         }
         warehouse.setWarehouseName(warehouseName);
         warehouse.setWarehouseNameKana(warehouseNameKana);
@@ -93,7 +93,7 @@ public class WarehouseService {
             return saved;
         } catch (ObjectOptimisticLockingFailureException e) {
             log.info("Warehouse update OL conflict detected at commit: id={}", id);
-            throw optimisticLockConflict();
+            throw OptimisticLockConflictException.standard();
         }
     }
 
@@ -103,7 +103,7 @@ public class WarehouseService {
         if (!warehouse.getVersion().equals(version)) {
             log.info("Warehouse toggleActive version mismatch: id={}, expected={}, actual={}",
                     id, version, warehouse.getVersion());
-            throw optimisticLockConflict();
+            throw OptimisticLockConflictException.standard();
         }
         // 冪等性のため、状態が実際に変化しない場合は早期 return（後続の在庫チェックも省略）
         if (warehouse.getIsActive().equals(isActive)) {
@@ -131,15 +131,8 @@ public class WarehouseService {
             return saved;
         } catch (ObjectOptimisticLockingFailureException e) {
             log.info("Warehouse toggleActive OL conflict detected at commit: id={}", id);
-            throw optimisticLockConflict();
+            throw OptimisticLockConflictException.standard();
         }
-    }
-
-    private OptimisticLockConflictException optimisticLockConflict() {
-        // OWASP A09: 例外メッセージには内部 id を含めない。id は log 側に出力する。
-        return new OptimisticLockConflictException(
-                "OPTIMISTIC_LOCK_CONFLICT",
-                "他のユーザーによる更新が先行しました");
     }
 
     public boolean existsByCode(String warehouseCode) {

--- a/backend/src/main/java/com/wms/master/service/WarehouseService.java
+++ b/backend/src/main/java/com/wms/master/service/WarehouseService.java
@@ -79,9 +79,9 @@ public class WarehouseService {
                             String address, Integer version) {
         Warehouse warehouse = findById(id);
         if (!warehouse.getVersion().equals(version)) {
-            throw new OptimisticLockConflictException(
-                    "OPTIMISTIC_LOCK_CONFLICT",
-                    "他のユーザーによる更新が先行しました (id=" + id + ")");
+            log.info("Warehouse update version mismatch: id={}, expected={}, actual={}",
+                    id, version, warehouse.getVersion());
+            throw optimisticLockConflict();
         }
         warehouse.setWarehouseName(warehouseName);
         warehouse.setWarehouseNameKana(warehouseNameKana);
@@ -92,9 +92,8 @@ public class WarehouseService {
             log.info("Warehouse updated: id={}, name={}", id, warehouseName);
             return saved;
         } catch (ObjectOptimisticLockingFailureException e) {
-            throw new OptimisticLockConflictException(
-                    "OPTIMISTIC_LOCK_CONFLICT",
-                    "他のユーザーによる更新が先行しました (id=" + id + ")");
+            log.info("Warehouse update OL conflict detected at commit: id={}", id);
+            throw optimisticLockConflict();
         }
     }
 
@@ -102,9 +101,9 @@ public class WarehouseService {
     public Warehouse toggleActive(Long id, boolean isActive, Integer version) {
         Warehouse warehouse = findById(id);
         if (!warehouse.getVersion().equals(version)) {
-            throw new OptimisticLockConflictException(
-                    "OPTIMISTIC_LOCK_CONFLICT",
-                    "他のユーザーによる更新が先行しました (id=" + id + ")");
+            log.info("Warehouse toggleActive version mismatch: id={}, expected={}, actual={}",
+                    id, version, warehouse.getVersion());
+            throw optimisticLockConflict();
         }
         // 冪等性のため、状態が実際に変化しない場合は早期 return（後続の在庫チェックも省略）
         if (warehouse.getIsActive().equals(isActive)) {
@@ -114,9 +113,11 @@ public class WarehouseService {
         // 無効化時: 在庫が存在する倉庫は無効化不可 (BR: CANNOT_DEACTIVATE_HAS_INVENTORY)
         // 上の no-op 判定により、状態が実際に変化する場合のみここに到達する
         if (!isActive && inventoryService.hasInventoryByWarehouseId(id)) {
+            // OWASP A09: 例外メッセージには内部 id を含めない。id は log 側に出力。
+            log.info("Warehouse deactivate blocked by inventory: id={}", id);
             throw new BusinessRuleViolationException(
                     "CANNOT_DEACTIVATE_HAS_INVENTORY",
-                    "在庫が存在するため無効化できません (id=" + id + ")");
+                    "在庫が存在するため無効化できません");
         }
         if (isActive) {
             warehouse.activate();
@@ -129,10 +130,16 @@ public class WarehouseService {
             log.info("Warehouse toggled: id={}, isActive={}", id, isActive);
             return saved;
         } catch (ObjectOptimisticLockingFailureException e) {
-            throw new OptimisticLockConflictException(
-                    "OPTIMISTIC_LOCK_CONFLICT",
-                    "他のユーザーによる更新が先行しました (id=" + id + ")");
+            log.info("Warehouse toggleActive OL conflict detected at commit: id={}", id);
+            throw optimisticLockConflict();
         }
+    }
+
+    private OptimisticLockConflictException optimisticLockConflict() {
+        // OWASP A09: 例外メッセージには内部 id を含めない。id は log 側に出力する。
+        return new OptimisticLockConflictException(
+                "OPTIMISTIC_LOCK_CONFLICT",
+                "他のユーザーによる更新が先行しました");
     }
 
     public boolean existsByCode(String warehouseCode) {

--- a/backend/src/main/java/com/wms/outbound/service/OutboundSlipService.java
+++ b/backend/src/main/java/com/wms/outbound/service/OutboundSlipService.java
@@ -73,9 +73,14 @@ public class OutboundSlipService {
 
     public OutboundSlip findByIdWithLines(Long id) {
         return outboundSlipRepository.findByIdWithLines(id)
-                .orElseThrow(() -> new ResourceNotFoundException(
-                        "OUTBOUND_SLIP_NOT_FOUND",
-                        "出荷伝票が見つかりません (id=" + id + ")"));
+                .orElseThrow(() -> {
+                    // SEC-R2-Min-1 (OWASP A09): クライアント向けメッセージから内部 id を除去し、
+                    // 追跡用 id はログ側に出力する
+                    log.info("OutboundSlip not found: id={}", id);
+                    return new ResourceNotFoundException(
+                            "OUTBOUND_SLIP_NOT_FOUND",
+                            "出荷伝票が見つかりません");
+                });
     }
 
     public long countLinesBySlipId(Long slipId) {
@@ -84,9 +89,13 @@ public class OutboundSlipService {
 
     public OutboundSlip findBySlipLineId(Long slipLineId) {
         return outboundSlipRepository.findBySlipLineId(slipLineId)
-                .orElseThrow(() -> new ResourceNotFoundException(
-                        "OUTBOUND_SLIP_NOT_FOUND",
-                        "出荷伝票が見つかりません (slipLineId=" + slipLineId + ")"));
+                .orElseThrow(() -> {
+                    // SEC-R2-Min-1 (OWASP A09): 追跡用 slipLineId はログへ
+                    log.info("OutboundSlip not found by slipLineId: slipLineId={}", slipLineId);
+                    return new ResourceNotFoundException(
+                            "OUTBOUND_SLIP_NOT_FOUND",
+                            "出荷伝票が見つかりません");
+                });
     }
 
     @Transactional
@@ -199,11 +208,15 @@ public class OutboundSlipService {
     @Transactional
     public void delete(Long id) {
         OutboundSlip slip = outboundSlipRepository.findByIdForUpdate(id)
-                .orElseThrow(() -> new ResourceNotFoundException(
-                        "OUTBOUND_SLIP_NOT_FOUND",
-                        "出荷伝票が見つかりません (id=" + id + ")"));
+                .orElseThrow(() -> {
+                    log.info("OutboundSlip not found on delete: id={}", id);
+                    return new ResourceNotFoundException(
+                            "OUTBOUND_SLIP_NOT_FOUND",
+                            "出荷伝票が見つかりません");
+                });
 
         if (!OutboundSlipStatus.ORDERED.getValue().equals(slip.getStatus())) {
+            log.info("OutboundSlip delete rejected due to status: id={}, status={}", id, slip.getStatus());
             throw new InvalidStateTransitionException("OUTBOUND_INVALID_STATUS",
                     "ORDERED以外のステータスの出荷伝票は削除できません (status=" + slip.getStatus() + ")");
         }
@@ -215,11 +228,15 @@ public class OutboundSlipService {
     @Transactional
     public OutboundSlip cancel(Long id, CancelOutboundRequest request) {
         OutboundSlip slip = outboundSlipRepository.findByIdForUpdate(id)
-                .orElseThrow(() -> new ResourceNotFoundException(
-                        "OUTBOUND_SLIP_NOT_FOUND",
-                        "出荷伝票が見つかりません (id=" + id + ")"));
+                .orElseThrow(() -> {
+                    log.info("OutboundSlip not found on cancel: id={}", id);
+                    return new ResourceNotFoundException(
+                            "OUTBOUND_SLIP_NOT_FOUND",
+                            "出荷伝票が見つかりません");
+                });
 
         if (!CANCELLABLE_STATUSES.contains(slip.getStatus())) {
+            log.info("OutboundSlip cancel rejected due to status: id={}, status={}", id, slip.getStatus());
             throw new InvalidStateTransitionException("OUTBOUND_INVALID_STATUS",
                     "キャンセル可能なステータスではありません (status=" + slip.getStatus() + ")");
         }

--- a/backend/src/main/java/com/wms/outbound/service/OutboundSlipService.java
+++ b/backend/src/main/java/com/wms/outbound/service/OutboundSlipService.java
@@ -112,8 +112,9 @@ public class OutboundSlipService {
         Set<Long> productIds = new HashSet<>();
         for (CreateOutboundLineRequest line : request.getLines()) {
             if (!productIds.add(line.getProductId())) {
+                log.info("OutboundSlip create duplicate product in lines: productId={}", line.getProductId());
                 throw new DuplicateResourceException("DUPLICATE_PRODUCT_IN_LINES",
-                        "同一伝票内に同じ商品が複数指定されています (productId=" + line.getProductId() + ")");
+                        "同一伝票内に同じ商品が複数指定されています");
             }
         }
 
@@ -142,13 +143,15 @@ public class OutboundSlipService {
             Product product = productService.findById(lineReq.getProductId());
 
             if (!Boolean.TRUE.equals(product.getIsActive())) {
+                log.info("OutboundSlip create product inactive: productId={}", product.getId());
                 throw new BusinessRuleViolationException("PRODUCT_INACTIVE",
-                        "無効な商品が指定されています (productId=" + product.getId() + ")");
+                        "無効な商品が指定されています");
             }
 
             if (Boolean.TRUE.equals(product.getShipmentStopFlag())) {
+                log.info("OutboundSlip create product shipment stopped: productId={}", product.getId());
                 throw new BusinessRuleViolationException("OUTBOUND_PRODUCT_SHIPMENT_STOPPED",
-                        "出荷禁止フラグが設定されている商品です (productId=" + product.getId() + ")");
+                        "出荷禁止フラグが設定されている商品です");
             }
 
             return new ProductLineInfo(product, lineReq);
@@ -218,7 +221,7 @@ public class OutboundSlipService {
         if (!OutboundSlipStatus.ORDERED.getValue().equals(slip.getStatus())) {
             log.info("OutboundSlip delete rejected due to status: id={}, status={}", id, slip.getStatus());
             throw new InvalidStateTransitionException("OUTBOUND_INVALID_STATUS",
-                    "ORDERED以外のステータスの出荷伝票は削除できません (status=" + slip.getStatus() + ")");
+                    "現在のステータスでは出荷伝票を削除できません");
         }
 
         outboundSlipRepository.delete(slip);
@@ -238,7 +241,7 @@ public class OutboundSlipService {
         if (!CANCELLABLE_STATUSES.contains(slip.getStatus())) {
             log.info("OutboundSlip cancel rejected due to status: id={}, status={}", id, slip.getStatus());
             throw new InvalidStateTransitionException("OUTBOUND_INVALID_STATUS",
-                    "キャンセル可能なステータスではありません (status=" + slip.getStatus() + ")");
+                    "現在のステータスでは出荷伝票をキャンセルできません");
         }
 
         Long currentUserId = getCurrentUserId();

--- a/backend/src/main/java/com/wms/outbound/service/PickingService.java
+++ b/backend/src/main/java/com/wms/outbound/service/PickingService.java
@@ -94,9 +94,13 @@ public class PickingService {
      */
     public PickingInstruction findByIdWithLines(Long id) {
         return pickingInstructionRepository.findByIdWithLines(id)
-                .orElseThrow(() -> new ResourceNotFoundException(
-                        "PICKING_NOT_FOUND",
-                        "ピッキング指示が見つかりません (id=" + id + ")"));
+                .orElseThrow(() -> {
+                    // SEC-R2-Min-1 (OWASP A09): 追跡用 id はログへ
+                    log.info("PickingInstruction not found: id={}", id);
+                    return new ResourceNotFoundException(
+                            "PICKING_NOT_FOUND",
+                            "ピッキング指示が見つかりません");
+                });
     }
 
     /**
@@ -135,14 +139,20 @@ public class PickingService {
         Long warehouseId = null;
         List<OutboundSlip> slips = new ArrayList<>();
         for (Long slipId : slipIds) {
+            final Long currentSlipId = slipId;
             OutboundSlip slip = outboundSlipRepository.findByIdWithLines(slipId)
-                    .orElseThrow(() -> new ResourceNotFoundException(
-                            "OUTBOUND_SLIP_NOT_FOUND",
-                            "出荷伝票が見つかりません (id=" + slipId + ")"));
+                    .orElseThrow(() -> {
+                        log.info("OutboundSlip not found during picking create: slipId={}", currentSlipId);
+                        return new ResourceNotFoundException(
+                                "OUTBOUND_SLIP_NOT_FOUND",
+                                "出荷伝票が見つかりません");
+                    });
 
             if (!OutboundSlipStatus.ALLOCATED.getValue().equals(slip.getStatus())) {
+                log.info("OutboundSlip not ALLOCATED during picking create: slipId={}, status={}",
+                        currentSlipId, slip.getStatus());
                 throw new InvalidStateTransitionException("OUTBOUND_INVALID_STATUS",
-                        "ALLOCATED以外のステータスの伝票が含まれています (id=" + slipId + ", status=" + slip.getStatus() + ")");
+                        "ALLOCATED以外のステータスの伝票が含まれています (status=" + slip.getStatus() + ")");
             }
 
             if (warehouseId == null) {
@@ -156,8 +166,9 @@ public class PickingService {
             List<UnpackInstruction> instructed = unpackInstructionRepository
                     .findByOutboundSlipIdAndStatus(slip.getId(), "INSTRUCTED");
             if (!instructed.isEmpty()) {
+                log.info("Picking creation blocked: pending unpack instructions exist: slipId={}", slip.getId());
                 throw new InvalidStateTransitionException("UNPACK_NOT_COMPLETED",
-                        "未完了のばらし指示が存在するため、ピッキング指示を作成できません (slipId=" + slip.getId() + ")");
+                        "未完了のばらし指示が存在するため、ピッキング指示を作成できません");
             }
         }
 
@@ -176,9 +187,12 @@ public class PickingService {
                 }
 
                 Location location = locationRepository.findById(alloc.getLocationId())
-                        .orElseThrow(() -> new ResourceNotFoundException(
-                                "LOCATION_NOT_FOUND",
-                                "ロケーションが見つかりません (id=" + alloc.getLocationId() + ")"));
+                        .orElseThrow(() -> {
+                            log.info("Location not found during picking create: locationId={}", alloc.getLocationId());
+                            return new ResourceNotFoundException(
+                                    "LOCATION_NOT_FOUND",
+                                    "ロケーションが見つかりません");
+                        });
 
                 // 出荷明細からproduct_code/name取得
                 OutboundSlipLine slipLine = slip.getLines().stream()
@@ -253,13 +267,17 @@ public class PickingService {
     @Transactional
     public PickingInstruction completePickingInstruction(Long id, CompletePickingRequest request) {
         PickingInstruction instruction = pickingInstructionRepository.findByIdForUpdate(id)
-                .orElseThrow(() -> new ResourceNotFoundException(
-                        "PICKING_NOT_FOUND",
-                        "ピッキング指示が見つかりません (id=" + id + ")"));
+                .orElseThrow(() -> {
+                    log.info("PickingInstruction not found on complete: id={}", id);
+                    return new ResourceNotFoundException(
+                            "PICKING_NOT_FOUND",
+                            "ピッキング指示が見つかりません");
+                });
 
         if (PickingInstructionStatus.COMPLETED.getValue().equals(instruction.getStatus())) {
+            log.info("PickingInstruction already completed: id={}", id);
             throw new InvalidStateTransitionException("OUTBOUND_INVALID_STATUS",
-                    "既に完了済みのピッキング指示です (id=" + id + ")");
+                    "既に完了済みのピッキング指示です");
         }
 
         // 明細IDのマップを作成
@@ -273,14 +291,16 @@ public class PickingService {
         for (CompletePickingLineRequest lineReq : request.getLines()) {
             PickingInstructionLine line = lineMap.get(lineReq.getLineId());
             if (line == null) {
+                log.info("Picking line not found: instructionId={}, lineId={}", id, lineReq.getLineId());
                 throw new BusinessRuleViolationException("PICKING_LINE_NOT_FOUND",
-                        "指定されたlineIdが当該ピッキング指示に存在しません (lineId=" + lineReq.getLineId() + ")");
+                        "指定されたlineIdが当該ピッキング指示に存在しません");
             }
 
             if (lineReq.getQtyPicked() > line.getQtyToPick()) {
+                log.info("Picking qty exceeded: instructionId={}, lineId={}, qtyPicked={}, qtyToPick={}",
+                        id, lineReq.getLineId(), lineReq.getQtyPicked(), line.getQtyToPick());
                 throw new BusinessRuleViolationException("PICKING_QTY_EXCEEDED",
-                        "ピッキング完了数量がピッキング予定数量を超えています (lineId=" + lineReq.getLineId()
-                                + ", qtyPicked=" + lineReq.getQtyPicked()
+                        "ピッキング完了数量がピッキング予定数量を超えています (qtyPicked=" + lineReq.getQtyPicked()
                                 + ", qtyToPick=" + line.getQtyToPick() + ")");
             }
 

--- a/backend/src/main/java/com/wms/outbound/service/PickingService.java
+++ b/backend/src/main/java/com/wms/outbound/service/PickingService.java
@@ -139,10 +139,9 @@ public class PickingService {
         Long warehouseId = null;
         List<OutboundSlip> slips = new ArrayList<>();
         for (Long slipId : slipIds) {
-            final Long currentSlipId = slipId;
             OutboundSlip slip = outboundSlipRepository.findByIdWithLines(slipId)
                     .orElseThrow(() -> {
-                        log.info("OutboundSlip not found during picking create: slipId={}", currentSlipId);
+                        log.info("OutboundSlip not found during picking create: slipId={}", slipId);
                         return new ResourceNotFoundException(
                                 "OUTBOUND_SLIP_NOT_FOUND",
                                 "出荷伝票が見つかりません");
@@ -150,9 +149,9 @@ public class PickingService {
 
             if (!OutboundSlipStatus.ALLOCATED.getValue().equals(slip.getStatus())) {
                 log.info("OutboundSlip not ALLOCATED during picking create: slipId={}, status={}",
-                        currentSlipId, slip.getStatus());
+                        slipId, slip.getStatus());
                 throw new InvalidStateTransitionException("OUTBOUND_INVALID_STATUS",
-                        "ALLOCATED以外のステータスの伝票が含まれています (status=" + slip.getStatus() + ")");
+                        "現在のステータスではピッキング指示を作成できません");
             }
 
             if (warehouseId == null) {
@@ -297,11 +296,10 @@ public class PickingService {
             }
 
             if (lineReq.getQtyPicked() > line.getQtyToPick()) {
-                log.info("Picking qty exceeded: instructionId={}, lineId={}, qtyPicked={}, qtyToPick={}",
+                log.warn("Picking qty exceeded: instructionId={}, lineId={}, qtyPicked={}, qtyToPick={}",
                         id, lineReq.getLineId(), lineReq.getQtyPicked(), line.getQtyToPick());
                 throw new BusinessRuleViolationException("PICKING_QTY_EXCEEDED",
-                        "ピッキング完了数量がピッキング予定数量を超えています (qtyPicked=" + lineReq.getQtyPicked()
-                                + ", qtyToPick=" + line.getQtyToPick() + ")");
+                        "ピッキング完了数量がピッキング予定数量を超えています");
             }
 
             line.setQtyPicked(lineReq.getQtyPicked());

--- a/backend/src/main/java/com/wms/returns/service/ReturnSlipService.java
+++ b/backend/src/main/java/com/wms/returns/service/ReturnSlipService.java
@@ -89,8 +89,9 @@ public class ReturnSlipService {
         // Validate product
         Product product = productService.findById(request.getProductId());
         if (!Boolean.TRUE.equals(product.getIsActive())) {
+            log.info("ReturnSlip create product inactive: productId={}", product.getId());
             throw new BusinessRuleViolationException("VALIDATION_ERROR",
-                    "無効な商品が指定されています (productId=" + product.getId() + ")");
+                    "無効な商品が指定されています");
         }
 
         // Validate partner (optional)
@@ -110,13 +111,16 @@ public class ReturnSlipService {
             location = locationService.findById(request.getLocationId());
 
             if (!location.getWarehouseId().equals(warehouse.getId())) {
+                log.info("ReturnSlip create location warehouse mismatch: locationId={}, warehouseId={}",
+                        location.getId(), warehouse.getId());
                 throw new BusinessRuleViolationException("RETURN_LOCATION_WAREHOUSE_MISMATCH",
-                        "指定のロケーションはこの倉庫に属していません (locationId=" + location.getId() + ")");
+                        "指定のロケーションはこの倉庫に属していません");
             }
 
             if (Boolean.TRUE.equals(location.getIsStocktakingLocked())) {
+                log.info("ReturnSlip create location stocktake locked: locationId={}", location.getId());
                 throw new BusinessRuleViolationException("RETURN_STOCKTAKE_LOCKED",
-                        "棚卸ロック中のロケーションからは返品できません (locationId=" + location.getId() + ")");
+                        "棚卸ロック中のロケーションからは返品できません");
             }
         }
 

--- a/backend/src/main/java/com/wms/shared/exception/OptimisticLockConflictException.java
+++ b/backend/src/main/java/com/wms/shared/exception/OptimisticLockConflictException.java
@@ -14,8 +14,12 @@ public final class OptimisticLockConflictException extends WmsException {
      *     Failures) に該当するため、全 Service で共通メッセージを用いる {@code standard()}
      *     に統一している。追跡用の識別子は呼び出し元 Service で throw 直前に
      *     {@code log.info} へ出力する運用とする。
+     *
+     *     <p><strong>削除予定はない:</strong> 本コンストラクタは {@code standard()} の
+     *     内部実装および既存テスト互換のため残置する方針。{@code forRemoval = false} を
+     *     明示する。</p>
      */
-    @Deprecated
+    @Deprecated(since = "2026-04-10", forRemoval = false)
     public OptimisticLockConflictException(String errorCode, String message) {
         super(errorCode, message);
     }

--- a/backend/src/main/java/com/wms/shared/exception/OptimisticLockConflictException.java
+++ b/backend/src/main/java/com/wms/shared/exception/OptimisticLockConflictException.java
@@ -6,10 +6,16 @@ public final class OptimisticLockConflictException extends WmsException {
     private static final String DEFAULT_CODE = "OPTIMISTIC_LOCK_CONFLICT";
     private static final String STANDARD_MESSAGE = "他のユーザーによる更新が先行しました";
 
-    public OptimisticLockConflictException() {
-        super(DEFAULT_CODE, "他のユーザーが更新済みです。画面を再読み込みしてください");
-    }
-
+    /**
+     * カスタム errorCode / message を指定するコンストラクタ。
+     *
+     * @deprecated 新規コードでは {@link #standard()} を使用すること。メッセージに内部 ID
+     *     (id / key / 伝票番号等) を含めると OWASP A09 (Security Logging and Monitoring
+     *     Failures) に該当するため、全 Service で共通メッセージを用いる {@code standard()}
+     *     に統一している。追跡用の識別子は呼び出し元 Service で throw 直前に
+     *     {@code log.info} へ出力する運用とする。
+     */
+    @Deprecated
     public OptimisticLockConflictException(String errorCode, String message) {
         super(errorCode, message);
     }
@@ -21,6 +27,7 @@ public final class OptimisticLockConflictException extends WmsException {
      * 例外メッセージには内部 PK (id) を含めない。追跡用の id は呼び出し元 (Service 層)
      * で例外 throw 前に log.info / log.warn へ出力すること。</p>
      */
+    @SuppressWarnings("deprecation")
     public static OptimisticLockConflictException standard() {
         return new OptimisticLockConflictException(DEFAULT_CODE, STANDARD_MESSAGE);
     }

--- a/backend/src/main/java/com/wms/shared/exception/OptimisticLockConflictException.java
+++ b/backend/src/main/java/com/wms/shared/exception/OptimisticLockConflictException.java
@@ -4,6 +4,7 @@ package com.wms.shared.exception;
 public final class OptimisticLockConflictException extends WmsException {
 
     private static final String DEFAULT_CODE = "OPTIMISTIC_LOCK_CONFLICT";
+    private static final String STANDARD_MESSAGE = "他のユーザーによる更新が先行しました";
 
     public OptimisticLockConflictException() {
         super(DEFAULT_CODE, "他のユーザーが更新済みです。画面を再読み込みしてください");
@@ -11,5 +12,16 @@ public final class OptimisticLockConflictException extends WmsException {
 
     public OptimisticLockConflictException(String errorCode, String message) {
         super(errorCode, message);
+    }
+
+    /**
+     * 標準ファクトリ: 全 Service 共通の楽観的ロック競合例外を生成する。
+     *
+     * <p>OWASP A09 (Security Logging and Monitoring Failures):
+     * 例外メッセージには内部 PK (id) を含めない。追跡用の id は呼び出し元 (Service 層)
+     * で例外 throw 前に log.info / log.warn へ出力すること。</p>
+     */
+    public static OptimisticLockConflictException standard() {
+        return new OptimisticLockConflictException(DEFAULT_CODE, STANDARD_MESSAGE);
     }
 }

--- a/backend/src/main/java/com/wms/shared/exception/ResourceNotFoundException.java
+++ b/backend/src/main/java/com/wms/shared/exception/ResourceNotFoundException.java
@@ -29,6 +29,16 @@ public final class ResourceNotFoundException extends WmsException {
      * <p>Pure factory (副作用なし) が必要になった場合は、本ファクトリではなく
      * コンストラクタ {@link #ResourceNotFoundException(String, String)} を直接使用すること。</p>
      *
+     * <p><strong>ロガー名に関する注意:</strong> 本ファクトリから出力されるログは
+     * {@code com.wms.shared.exception.ResourceNotFoundException} ロガーで発行される
+     * (呼び出し元 Service クラスのロガーではない)。運用ログ検索時に発生源 Service を
+     * ロガー名で特定したい場合は、本ファクトリを使わず、呼び出し元 Service 層で
+     * 先に {@code log.info(...)} を明示的に出力してから 2 引数コンストラクタ
+     * {@link #ResourceNotFoundException(String, String)} を直接使用すること。
+     * メッセージ本文 ({@code "{resourceName} not found: id=..., errorCode=..."}) と
+     * resourceName はロガー名に依らず一意に grep 可能なため、通常運用では本ファクトリの
+     * 利用で差し支えない (MDC の traceId も併用される)。</p>
+     *
      * @param id 内部 PK — メッセージには埋め込まれず、ログ出力専用。
      */
     public static ResourceNotFoundException of(String errorCode, String resourceName, Object id) {

--- a/backend/src/main/java/com/wms/shared/exception/ResourceNotFoundException.java
+++ b/backend/src/main/java/com/wms/shared/exception/ResourceNotFoundException.java
@@ -1,7 +1,12 @@
 package com.wms.shared.exception;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /** 404 Not Found — 指定リソースが存在しない */
 public final class ResourceNotFoundException extends WmsException {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ResourceNotFoundException.class);
 
     public ResourceNotFoundException(String errorCode, String message) {
         super(errorCode, message);
@@ -11,13 +16,13 @@ public final class ResourceNotFoundException extends WmsException {
      * 汎用ファクトリ: "XXX が見つかりません".
      *
      * <p>OWASP A09 (Security Logging and Monitoring Failures): 例外メッセージには内部 PK (id)
-     * を含めない。ID 列挙攻撃への補助情報を与えないため。追跡用の id は呼び出し元 (Service 層)
-     * でログ側 (log.info / log.warn) に出力すること。</p>
+     * を含めない。ID 列挙攻撃への補助情報を与えないため。追跡用の id はこのファクトリ内部で
+     * サーバーログ (log.info) へ出力する。</p>
      *
-     * @param id 内部 PK — メッセージには埋め込まれないが、互換性のためシグネチャに残している。
-     *           将来的に呼び出し元がログ出力していることを保証できたら削除可能。
+     * @param id 内部 PK — メッセージには埋め込まれず、ログ出力専用。
      */
     public static ResourceNotFoundException of(String errorCode, String resourceName, Object id) {
+        LOG.info("{} not found: id={}, errorCode={}", resourceName, id, errorCode);
         return new ResourceNotFoundException(errorCode,
                 String.format("%s が見つかりません", resourceName));
     }

--- a/backend/src/main/java/com/wms/shared/exception/ResourceNotFoundException.java
+++ b/backend/src/main/java/com/wms/shared/exception/ResourceNotFoundException.java
@@ -7,9 +7,18 @@ public final class ResourceNotFoundException extends WmsException {
         super(errorCode, message);
     }
 
-    /** 汎用ファクトリ: "XXX が見つかりません (id=123)" */
+    /**
+     * 汎用ファクトリ: "XXX が見つかりません".
+     *
+     * <p>OWASP A09 (Security Logging and Monitoring Failures): 例外メッセージには内部 PK (id)
+     * を含めない。ID 列挙攻撃への補助情報を与えないため。追跡用の id は呼び出し元 (Service 層)
+     * でログ側 (log.info / log.warn) に出力すること。</p>
+     *
+     * @param id 内部 PK — メッセージには埋め込まれないが、互換性のためシグネチャに残している。
+     *           将来的に呼び出し元がログ出力していることを保証できたら削除可能。
+     */
     public static ResourceNotFoundException of(String errorCode, String resourceName, Object id) {
         return new ResourceNotFoundException(errorCode,
-                String.format("%s が見つかりません (id=%s)", resourceName, id));
+                String.format("%s が見つかりません", resourceName));
     }
 }

--- a/backend/src/main/java/com/wms/shared/exception/ResourceNotFoundException.java
+++ b/backend/src/main/java/com/wms/shared/exception/ResourceNotFoundException.java
@@ -19,6 +19,16 @@ public final class ResourceNotFoundException extends WmsException {
      * を含めない。ID 列挙攻撃への補助情報を与えないため。追跡用の id はこのファクトリ内部で
      * サーバーログ (log.info) へ出力する。</p>
      *
+     * <p><strong>副作用に関する設計上の注意:</strong> 本ファクトリは「例外構築時」に
+     * {@code log.info} を出力する副作用を意図的に持つ。これにより呼び出し元
+     * ({@code orElseThrow(() -> ResourceNotFoundException.of(...))}) で追加のログ記述を
+     * 不要とし、全モジュールの「リソース未検出ログ」フォーマットを一元化している。
+     * この副作用は本クラスの仕様であり、呼び出し元で {@code log.info} を重複して
+     * 出力する必要は無い (むしろ禁止)。</p>
+     *
+     * <p>Pure factory (副作用なし) が必要になった場合は、本ファクトリではなく
+     * コンストラクタ {@link #ResourceNotFoundException(String, String)} を直接使用すること。</p>
+     *
      * @param id 内部 PK — メッセージには埋め込まれず、ログ出力専用。
      */
     public static ResourceNotFoundException of(String errorCode, String resourceName, Object id) {

--- a/backend/src/main/java/com/wms/system/service/SystemParameterService.java
+++ b/backend/src/main/java/com/wms/system/service/SystemParameterService.java
@@ -40,9 +40,8 @@ public class SystemParameterService {
     public SystemParameter updateValue(String paramKey, String paramValue, Integer version) {
         SystemParameter param = findByKey(paramKey);
         if (!param.getVersion().equals(version)) {
-            throw new OptimisticLockConflictException(
-                    "OPTIMISTIC_LOCK_CONFLICT",
-                    "他のユーザーによる更新が先行しました (key=" + paramKey + ")");
+            log.info("SystemParameter optimistic lock conflict: key={}", paramKey);
+            throw OptimisticLockConflictException.standard();
         }
         validateParamValue(param, paramValue);
         // BOOLEAN型は小文字に正規化（大文字小文字の揺れを防止）
@@ -55,9 +54,8 @@ public class SystemParameterService {
             log.info("SystemParameter updated: key={}", paramKey);
             return saved;
         } catch (ObjectOptimisticLockingFailureException e) {
-            throw new OptimisticLockConflictException(
-                    "OPTIMISTIC_LOCK_CONFLICT",
-                    "他のユーザーによる更新が先行しました (key=" + paramKey + ")");
+            log.info("SystemParameter optimistic lock conflict: key={}", paramKey);
+            throw OptimisticLockConflictException.standard();
         }
     }
 

--- a/backend/src/main/java/com/wms/system/service/UserService.java
+++ b/backend/src/main/java/com/wms/system/service/UserService.java
@@ -67,7 +67,7 @@ public class UserService {
         if (!user.getVersion().equals(cmd.version())) {
             log.info("User update version mismatch: id={}, expected={}, actual={}",
                     cmd.id(), cmd.version(), user.getVersion());
-            throw optimisticLockConflict();
+            throw OptimisticLockConflictException.standard();
         }
         // 自己ロール変更禁止
         if (cmd.currentUserId().equals(cmd.id())
@@ -92,7 +92,7 @@ public class UserService {
             return saved;
         } catch (ObjectOptimisticLockingFailureException e) {
             log.info("User update OL conflict detected at commit: id={}", cmd.id());
-            throw optimisticLockConflict();
+            throw OptimisticLockConflictException.standard();
         }
     }
 
@@ -107,7 +107,7 @@ public class UserService {
         if (!user.getVersion().equals(version)) {
             log.info("User toggleActive version mismatch: id={}, expected={}, actual={}",
                     id, version, user.getVersion());
-            throw optimisticLockConflict();
+            throw OptimisticLockConflictException.standard();
         }
         // 冪等性: 既に同じ状態なら更新しない
         if (user.getIsActive().equals(isActive)) {
@@ -122,15 +122,8 @@ public class UserService {
             return saved;
         } catch (ObjectOptimisticLockingFailureException e) {
             log.info("User toggleActive OL conflict detected at commit: id={}", id);
-            throw optimisticLockConflict();
+            throw OptimisticLockConflictException.standard();
         }
-    }
-
-    private OptimisticLockConflictException optimisticLockConflict() {
-        // OWASP A09: 例外メッセージには内部 id を含めない。id は log 側に出力する。
-        return new OptimisticLockConflictException(
-                "OPTIMISTIC_LOCK_CONFLICT",
-                "他のユーザーによる更新が先行しました");
     }
 
     @Transactional

--- a/backend/src/main/java/com/wms/system/service/UserService.java
+++ b/backend/src/main/java/com/wms/system/service/UserService.java
@@ -65,9 +65,9 @@ public class UserService {
     public User update(UpdateUserCommand cmd) {
         User user = findById(cmd.id());
         if (!user.getVersion().equals(cmd.version())) {
-            throw new OptimisticLockConflictException(
-                    "OPTIMISTIC_LOCK_CONFLICT",
-                    "他のユーザーによる更新が先行しました (id=" + cmd.id() + ")");
+            log.info("User update version mismatch: id={}, expected={}, actual={}",
+                    cmd.id(), cmd.version(), user.getVersion());
+            throw optimisticLockConflict();
         }
         // 自己ロール変更禁止
         if (cmd.currentUserId().equals(cmd.id())
@@ -91,9 +91,8 @@ public class UserService {
             log.info("User updated: id={}, fullName={}", cmd.id(), cmd.fullName());
             return saved;
         } catch (ObjectOptimisticLockingFailureException e) {
-            throw new OptimisticLockConflictException(
-                    "OPTIMISTIC_LOCK_CONFLICT",
-                    "他のユーザーによる更新が先行しました (id=" + cmd.id() + ")");
+            log.info("User update OL conflict detected at commit: id={}", cmd.id());
+            throw optimisticLockConflict();
         }
     }
 
@@ -106,9 +105,9 @@ public class UserService {
                     "自分自身を無効化することはできません");
         }
         if (!user.getVersion().equals(version)) {
-            throw new OptimisticLockConflictException(
-                    "OPTIMISTIC_LOCK_CONFLICT",
-                    "他のユーザーによる更新が先行しました (id=" + id + ")");
+            log.info("User toggleActive version mismatch: id={}, expected={}, actual={}",
+                    id, version, user.getVersion());
+            throw optimisticLockConflict();
         }
         // 冪等性: 既に同じ状態なら更新しない
         if (user.getIsActive().equals(isActive)) {
@@ -122,10 +121,16 @@ public class UserService {
             log.info("User toggled: id={}, isActive={}", id, isActive);
             return saved;
         } catch (ObjectOptimisticLockingFailureException e) {
-            throw new OptimisticLockConflictException(
-                    "OPTIMISTIC_LOCK_CONFLICT",
-                    "他のユーザーによる更新が先行しました (id=" + id + ")");
+            log.info("User toggleActive OL conflict detected at commit: id={}", id);
+            throw optimisticLockConflict();
         }
+    }
+
+    private OptimisticLockConflictException optimisticLockConflict() {
+        // OWASP A09: 例外メッセージには内部 id を含めない。id は log 側に出力する。
+        return new OptimisticLockConflictException(
+                "OPTIMISTIC_LOCK_CONFLICT",
+                "他のユーザーによる更新が先行しました");
     }
 
     @Transactional

--- a/backend/src/test/java/com/wms/allocation/service/AllocationServiceTest.java
+++ b/backend/src/test/java/com/wms/allocation/service/AllocationServiceTest.java
@@ -411,7 +411,7 @@ class AllocationServiceTest {
 
             assertThatThrownBy(() -> allocationService.executeAllocation(request))
                     .isInstanceOf(InvalidStateTransitionException.class)
-                    .hasMessageContaining("引当可能なステータスではありません")
+                    .hasMessageContaining("現在のステータスでは引当できません")
                     .hasMessageNotContaining("id=");
         }
 
@@ -1394,7 +1394,7 @@ class AllocationServiceTest {
 
             assertThatThrownBy(() -> allocationService.releaseAllocation(request))
                     .isInstanceOf(InvalidStateTransitionException.class)
-                    .hasMessageContaining("引当解放可能なステータスではありません")
+                    .hasMessageContaining("現在のステータスでは引当を解放できません")
                     .hasMessageNotContaining("id=");
         }
 

--- a/backend/src/test/java/com/wms/allocation/service/AllocationServiceTest.java
+++ b/backend/src/test/java/com/wms/allocation/service/AllocationServiceTest.java
@@ -411,7 +411,8 @@ class AllocationServiceTest {
 
             assertThatThrownBy(() -> allocationService.executeAllocation(request))
                     .isInstanceOf(InvalidStateTransitionException.class)
-                    .hasMessageContaining("引当可能なステータスではありません");
+                    .hasMessageContaining("引当可能なステータスではありません")
+                    .hasMessageNotContaining("id=");
         }
 
         @Test
@@ -511,7 +512,8 @@ class AllocationServiceTest {
 
             assertThatThrownBy(() -> allocationService.executeAllocation(request))
                     .isInstanceOf(ResourceNotFoundException.class)
-                    .hasMessageContaining("出荷伝票が見つかりません");
+                    .hasMessageContaining("出荷伝票が見つかりません")
+                    .hasMessageNotContaining("id=");
         }
 
         @Test
@@ -651,7 +653,8 @@ class AllocationServiceTest {
 
             assertThatThrownBy(() -> allocationService.executeAllocation(request))
                     .isInstanceOf(ResourceNotFoundException.class)
-                    .hasMessageContaining("在庫が見つかりません");
+                    .hasMessageContaining("在庫が見つかりません")
+                    .hasMessageNotContaining("id=");
         }
 
         @Test
@@ -676,7 +679,8 @@ class AllocationServiceTest {
 
             assertThatThrownBy(() -> allocationService.executeAllocation(request))
                     .isInstanceOf(ResourceNotFoundException.class)
-                    .hasMessageContaining("在庫が見つかりません");
+                    .hasMessageContaining("在庫が見つかりません")
+                    .hasMessageNotContaining("id=");
         }
 
         @Test
@@ -969,7 +973,8 @@ class AllocationServiceTest {
 
             assertThatThrownBy(() -> allocationService.completeUnpackInstruction(500L))
                     .isInstanceOf(InvalidStateTransitionException.class)
-                    .hasMessageContaining("既に完了済みのばらし指示です");
+                    .hasMessageContaining("既に完了済みのばらし指示です")
+                    .hasMessageNotContaining("id=");
         }
 
         @Test
@@ -992,7 +997,8 @@ class AllocationServiceTest {
 
             assertThatThrownBy(() -> allocationService.completeUnpackInstruction(500L))
                     .isInstanceOf(ResourceNotFoundException.class)
-                    .hasMessageContaining("ロケーションが見つかりません");
+                    .hasMessageContaining("ロケーションが見つかりません")
+                    .hasMessageNotContaining("id=");
         }
 
         @Test
@@ -1019,7 +1025,8 @@ class AllocationServiceTest {
 
             assertThatThrownBy(() -> allocationService.completeUnpackInstruction(500L))
                     .isInstanceOf(ResourceNotFoundException.class)
-                    .hasMessageContaining("ばらし元在庫が見つかりません");
+                    .hasMessageContaining("ばらし元在庫が見つかりません")
+                    .hasMessageNotContaining("id=");
         }
 
         @Test
@@ -1088,7 +1095,8 @@ class AllocationServiceTest {
 
             assertThatThrownBy(() -> allocationService.completeUnpackInstruction(500L))
                     .isInstanceOf(ResourceNotFoundException.class)
-                    .hasMessageContaining("ばらし元在庫が見つかりません");
+                    .hasMessageContaining("ばらし元在庫が見つかりません")
+                    .hasMessageNotContaining("id=");
         }
 
         @Test
@@ -1122,7 +1130,8 @@ class AllocationServiceTest {
 
             assertThatThrownBy(() -> allocationService.completeUnpackInstruction(500L))
                     .isInstanceOf(BusinessRuleViolationException.class)
-                    .hasMessageContaining("ばらし指示に元在庫IDが設定されていません");
+                    .hasMessageContaining("ばらし指示に元在庫IDが設定されていません")
+                    .hasMessageNotContaining("unpackId=");
         }
 
         @Test
@@ -1279,7 +1288,8 @@ class AllocationServiceTest {
 
             assertThatThrownBy(() -> allocationService.completeUnpackInstruction(999L))
                     .isInstanceOf(ResourceNotFoundException.class)
-                    .hasMessageContaining("ばらし指示が見つかりません");
+                    .hasMessageContaining("ばらし指示が見つかりません")
+                    .hasMessageNotContaining("id=");
         }
     }
 
@@ -1384,7 +1394,8 @@ class AllocationServiceTest {
 
             assertThatThrownBy(() -> allocationService.releaseAllocation(request))
                     .isInstanceOf(InvalidStateTransitionException.class)
-                    .hasMessageContaining("引当解放可能なステータスではありません");
+                    .hasMessageContaining("引当解放可能なステータスではありません")
+                    .hasMessageNotContaining("id=");
         }
 
         @Test

--- a/backend/src/test/java/com/wms/inbound/service/InboundSlipServiceTest.java
+++ b/backend/src/test/java/com/wms/inbound/service/InboundSlipServiceTest.java
@@ -257,6 +257,7 @@ class InboundSlipServiceTest {
             assertThatThrownBy(() -> inboundSlipService.findById(999L))
                     .isInstanceOf(ResourceNotFoundException.class)
                     .hasMessageContaining("入荷伝票")
+                    .hasMessageNotContaining("id=")
                     .extracting("errorCode").isEqualTo("INBOUND_SLIP_NOT_FOUND");
         }
     }
@@ -286,6 +287,8 @@ class InboundSlipServiceTest {
 
             assertThatThrownBy(() -> inboundSlipService.findByIdWithLines(999L))
                     .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageContaining("入荷伝票")
+                    .hasMessageNotContaining("id=")
                     .extracting("errorCode").isEqualTo("INBOUND_SLIP_NOT_FOUND");
         }
     }
@@ -1331,6 +1334,8 @@ class InboundSlipServiceTest {
 
             assertThatThrownBy(() -> inboundSlipService.inspect(1L, request))
                     .isInstanceOf(InvalidStateTransitionException.class)
+                    .hasMessageNotContaining("lineId=")
+                    .hasMessageNotContaining("id=")
                     .extracting("errorCode").isEqualTo("INBOUND_LINE_ALREADY_STORED");
         }
 
@@ -1348,6 +1353,8 @@ class InboundSlipServiceTest {
 
             assertThatThrownBy(() -> inboundSlipService.inspect(1L, request))
                     .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageNotContaining("lineId=")
+                    .hasMessageNotContaining("id=")
                     .extracting("errorCode").isEqualTo("INBOUND_LINE_NOT_FOUND");
         }
 
@@ -1427,6 +1434,8 @@ class InboundSlipServiceTest {
 
             assertThatThrownBy(() -> inboundSlipService.inspect(1L, request))
                     .isInstanceOf(BusinessRuleViolationException.class)
+                    .hasMessageNotContaining("lineId=")
+                    .hasMessageNotContaining("id=")
                     .extracting("errorCode").isEqualTo("DUPLICATE_LINE_IN_REQUEST");
         }
 
@@ -1443,6 +1452,8 @@ class InboundSlipServiceTest {
 
             assertThatThrownBy(() -> inboundSlipService.inspect(1L, request))
                     .isInstanceOf(BusinessRuleViolationException.class)
+                    .hasMessageNotContaining("lineId=")
+                    .hasMessageNotContaining("id=")
                     .extracting("errorCode").isEqualTo("INBOUND_INSPECTED_QTY_NEGATIVE");
         }
 
@@ -1855,6 +1866,8 @@ class InboundSlipServiceTest {
 
             assertThatThrownBy(() -> inboundSlipService.store(1L, request))
                     .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageNotContaining("lineId=")
+                    .hasMessageNotContaining("id=")
                     .extracting("errorCode").isEqualTo("INBOUND_LINE_NOT_FOUND");
         }
 
@@ -1928,6 +1941,8 @@ class InboundSlipServiceTest {
 
             assertThatThrownBy(() -> inboundSlipService.store(1L, request))
                     .isInstanceOf(BusinessRuleViolationException.class)
+                    .hasMessageNotContaining("lineId=")
+                    .hasMessageNotContaining("id=")
                     .extracting("errorCode").isEqualTo("DUPLICATE_LINE_IN_REQUEST");
         }
 

--- a/backend/src/test/java/com/wms/inventory/service/StocktakeQueryServiceTest.java
+++ b/backend/src/test/java/com/wms/inventory/service/StocktakeQueryServiceTest.java
@@ -130,7 +130,9 @@ class StocktakeQueryServiceTest {
     void findByIdWithLines_notFound() {
         when(headerRepository.findByIdWithLines(999L)).thenReturn(Optional.empty());
         assertThatThrownBy(() -> service.findByIdWithLines(999L))
-                .isInstanceOf(ResourceNotFoundException.class);
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("棚卸が見つかりません")
+                .hasMessageNotContaining("id=");
     }
 
     @Test
@@ -156,7 +158,8 @@ class StocktakeQueryServiceTest {
         when(headerRepository.findById(999L)).thenReturn(Optional.empty());
         assertThatThrownBy(() -> service.findById(999L))
                 .isInstanceOf(ResourceNotFoundException.class)
-                .hasMessageContaining("棚卸が見つかりません");
+                .hasMessageContaining("棚卸が見つかりません")
+                .hasMessageNotContaining("id=");
     }
 
     @Test

--- a/backend/src/test/java/com/wms/inventory/service/StocktakeServiceTest.java
+++ b/backend/src/test/java/com/wms/inventory/service/StocktakeServiceTest.java
@@ -336,6 +336,8 @@ class StocktakeServiceTest {
             var inputs = List.of(new StocktakeService.LineInput(10L, 5));
             assertThatThrownBy(() -> service.saveStocktakeLines(999L, inputs))
                     .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageContaining("棚卸が見つかりません")
+                    .hasMessageNotContaining("id=")
                     .extracting("errorCode").isEqualTo("STOCKTAKE_NOT_FOUND");
         }
 
@@ -384,6 +386,9 @@ class StocktakeServiceTest {
             var inputs = List.of(new StocktakeService.LineInput(999L, 5));
             assertThatThrownBy(() -> service.saveStocktakeLines(1L, inputs))
                     .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageContaining("棚卸明細が見つかりません")
+                    .hasMessageNotContaining("lineId=")
+                    .hasMessageNotContaining("id=")
                     .extracting("errorCode").isEqualTo("STOCKTAKE_LINE_NOT_FOUND");
         }
 
@@ -412,6 +417,8 @@ class StocktakeServiceTest {
             var inputs = List.of(new StocktakeService.LineInput(10L, 5));
             assertThatThrownBy(() -> service.saveStocktakeLines(1L, inputs))
                     .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageNotContaining("lineId=")
+                    .hasMessageNotContaining("id=")
                     .extracting("errorCode").isEqualTo("STOCKTAKE_LINE_NOT_FOUND");
         }
     }
@@ -482,6 +489,8 @@ class StocktakeServiceTest {
 
             assertThatThrownBy(() -> service.confirmStocktake(999L))
                     .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageContaining("棚卸が見つかりません")
+                    .hasMessageNotContaining("id=")
                     .extracting("errorCode").isEqualTo("STOCKTAKE_NOT_FOUND");
         }
 

--- a/backend/src/test/java/com/wms/master/controller/PartnerControllerTest.java
+++ b/backend/src/test/java/com/wms/master/controller/PartnerControllerTest.java
@@ -336,7 +336,7 @@ class PartnerControllerTest {
         @DisplayName("楽観的ロック競合で409を返す")
         void update_conflict_returns409() throws Exception {
             when(partnerService.update(any(com.wms.master.service.UpdatePartnerCommand.class)))
-                    .thenThrow(new OptimisticLockConflictException("OPTIMISTIC_LOCK_CONFLICT", "競合"));
+                    .thenThrow(OptimisticLockConflictException.standard());
 
             UpdatePartnerRequest request = new UpdatePartnerRequest()
                     .partnerName("名前")
@@ -425,7 +425,7 @@ class PartnerControllerTest {
         @DisplayName("楽観的ロック競合で409を返す")
         void toggle_conflict_returns409() throws Exception {
             when(partnerService.toggleActive(eq(1L), eq(false), eq(0)))
-                    .thenThrow(new OptimisticLockConflictException("OPTIMISTIC_LOCK_CONFLICT", "競合"));
+                    .thenThrow(OptimisticLockConflictException.standard());
 
             ToggleActiveRequest request = new ToggleActiveRequest()
                     .isActive(false)

--- a/backend/src/test/java/com/wms/master/controller/WarehouseControllerTest.java
+++ b/backend/src/test/java/com/wms/master/controller/WarehouseControllerTest.java
@@ -294,7 +294,7 @@ class WarehouseControllerTest {
         @DisplayName("楽観的ロック競合で409を返す")
         void update_conflict_returns409() throws Exception {
             when(warehouseService.update(eq(1L), any(), any(), any(), any()))
-                    .thenThrow(new OptimisticLockConflictException("OPTIMISTIC_LOCK_CONFLICT", "競合"));
+                    .thenThrow(OptimisticLockConflictException.standard());
 
             UpdateWarehouseRequest request = new UpdateWarehouseRequest()
                     .warehouseName("名前")

--- a/backend/src/test/java/com/wms/outbound/service/OutboundSlipServiceTest.java
+++ b/backend/src/test/java/com/wms/outbound/service/OutboundSlipServiceTest.java
@@ -190,6 +190,7 @@ class OutboundSlipServiceTest {
 
             assertThatThrownBy(() -> outboundSlipService.findByIdWithLines(999L))
                     .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageNotContaining("id=")
                     .extracting("errorCode").isEqualTo("OUTBOUND_SLIP_NOT_FOUND");
         }
     }
@@ -510,6 +511,7 @@ class OutboundSlipServiceTest {
 
             assertThatThrownBy(() -> outboundSlipService.delete(999L))
                     .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageNotContaining("id=")
                     .extracting("errorCode").isEqualTo("OUTBOUND_SLIP_NOT_FOUND");
         }
 
@@ -615,6 +617,7 @@ class OutboundSlipServiceTest {
 
             assertThatThrownBy(() -> outboundSlipService.cancel(999L, new CancelOutboundRequest()))
                     .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageNotContaining("id=")
                     .extracting("errorCode").isEqualTo("OUTBOUND_SLIP_NOT_FOUND");
         }
 
@@ -664,6 +667,7 @@ class OutboundSlipServiceTest {
 
             assertThatThrownBy(() -> outboundSlipService.findBySlipLineId(999L))
                     .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageNotContaining("slipLineId=")
                     .extracting("errorCode").isEqualTo("OUTBOUND_SLIP_NOT_FOUND");
         }
     }

--- a/backend/src/test/java/com/wms/outbound/service/PickingServiceTest.java
+++ b/backend/src/test/java/com/wms/outbound/service/PickingServiceTest.java
@@ -310,7 +310,8 @@ class PickingServiceTest {
 
             assertThatThrownBy(() -> pickingService.findByIdWithLines(999L))
                     .isInstanceOf(ResourceNotFoundException.class)
-                    .hasMessageContaining("ピッキング指示が見つかりません");
+                    .hasMessageContaining("ピッキング指示が見つかりません")
+                    .hasMessageNotContaining("id=");
         }
     }
 
@@ -394,7 +395,8 @@ class PickingServiceTest {
 
             assertThatThrownBy(() -> pickingService.createPickingInstruction(request))
                     .isInstanceOf(InvalidStateTransitionException.class)
-                    .hasMessageContaining("ステータス");
+                    .hasMessageContaining("ステータス")
+                    .hasMessageNotContaining("id=");
         }
 
         @Test
@@ -406,7 +408,8 @@ class PickingServiceTest {
 
             assertThatThrownBy(() -> pickingService.createPickingInstruction(request))
                     .isInstanceOf(ResourceNotFoundException.class)
-                    .hasMessageContaining("出荷伝票が見つかりません");
+                    .hasMessageContaining("出荷伝票が見つかりません")
+                    .hasMessageNotContaining("id=");
         }
 
         @Test
@@ -426,7 +429,8 @@ class PickingServiceTest {
 
             assertThatThrownBy(() -> pickingService.createPickingInstruction(request))
                     .isInstanceOf(InvalidStateTransitionException.class)
-                    .hasMessageContaining("未完了のばらし指示が存在する");
+                    .hasMessageContaining("未完了のばらし指示が存在する")
+                    .hasMessageNotContaining("slipId=");
         }
 
         @Test
@@ -628,7 +632,8 @@ class PickingServiceTest {
 
             assertThatThrownBy(() -> pickingService.createPickingInstruction(request))
                     .isInstanceOf(ResourceNotFoundException.class)
-                    .hasMessageContaining("ロケーションが見つかりません");
+                    .hasMessageContaining("ロケーションが見つかりません")
+                    .hasMessageNotContaining("id=");
         }
 
         @Test
@@ -827,7 +832,8 @@ class PickingServiceTest {
 
             assertThatThrownBy(() -> pickingService.completePickingInstruction(50L, request))
                     .isInstanceOf(InvalidStateTransitionException.class)
-                    .hasMessageContaining("完了済み");
+                    .hasMessageContaining("完了済み")
+                    .hasMessageNotContaining("id=");
         }
 
         @Test
@@ -849,7 +855,8 @@ class PickingServiceTest {
                     .isInstanceOf(BusinessRuleViolationException.class)
                     .satisfies(ex -> assertThat(((BusinessRuleViolationException) ex).getErrorCode())
                             .isEqualTo("PICKING_LINE_NOT_FOUND"))
-                    .hasMessageContaining("lineIdが当該ピッキング指示に存在しません");
+                    .hasMessageContaining("lineIdが当該ピッキング指示に存在しません")
+                    .hasMessageNotContaining("lineId=");
         }
 
         @Test
@@ -871,7 +878,8 @@ class PickingServiceTest {
                     .isInstanceOf(BusinessRuleViolationException.class)
                     .satisfies(ex -> assertThat(((BusinessRuleViolationException) ex).getErrorCode())
                             .isEqualTo("PICKING_QTY_EXCEEDED"))
-                    .hasMessageContaining("ピッキング完了数量がピッキング予定数量を超えています");
+                    .hasMessageContaining("ピッキング完了数量がピッキング予定数量を超えています")
+                    .hasMessageNotContaining("lineId=");
         }
 
         @Test
@@ -884,7 +892,8 @@ class PickingServiceTest {
 
             assertThatThrownBy(() -> pickingService.completePickingInstruction(999L, request))
                     .isInstanceOf(ResourceNotFoundException.class)
-                    .hasMessageContaining("ピッキング指示が見つかりません");
+                    .hasMessageContaining("ピッキング指示が見つかりません")
+                    .hasMessageNotContaining("id=");
         }
     }
 

--- a/backend/src/test/java/com/wms/shared/exception/ExceptionClassesTest.java
+++ b/backend/src/test/java/com/wms/shared/exception/ExceptionClassesTest.java
@@ -104,16 +104,8 @@ class ExceptionClassesTest {
     class OptimisticLockConflictExceptionTest {
 
         @Test
-        @DisplayName("デフォルトコンストラクタ: デフォルトのcodeとmessageが設定される")
-        void constructor_default_setsDefaultCodeAndMessage() {
-            OptimisticLockConflictException ex = new OptimisticLockConflictException();
-
-            assertThat(ex.getErrorCode()).isEqualTo("OPTIMISTIC_LOCK_CONFLICT");
-            assertThat(ex.getMessage()).isEqualTo("他のユーザーが更新済みです。画面を再読み込みしてください");
-        }
-
-        @Test
-        @DisplayName("パラメータ付きコンストラクタ: カスタムのcodeとmessageが設定される")
+        @DisplayName("パラメータ付きコンストラクタ (@Deprecated): カスタムのcodeとmessageが設定される")
+        @SuppressWarnings("deprecation")
         void constructor_withCustomValues_setsFields() {
             OptimisticLockConflictException ex =
                     new OptimisticLockConflictException("CUSTOM_LOCK", "カスタムメッセージ");

--- a/backend/src/test/java/com/wms/shared/exception/ExceptionClassesTest.java
+++ b/backend/src/test/java/com/wms/shared/exception/ExceptionClassesTest.java
@@ -51,20 +51,24 @@ class ExceptionClassesTest {
         }
 
         @Test
-        @DisplayName("of(): リソース名とIDでメッセージが生成される")
-        void of_withResourceNameAndLongId_createsFormattedMessage() {
+        @DisplayName("of(): リソース名のみのメッセージが生成される (内部IDは埋め込まない: OWASP A09)")
+        void of_withResourceNameAndLongId_createsFormattedMessageWithoutId() {
             ResourceNotFoundException ex = ResourceNotFoundException.of("WAREHOUSE_NOT_FOUND", "倉庫", 42L);
 
             assertThat(ex.getErrorCode()).isEqualTo("WAREHOUSE_NOT_FOUND");
-            assertThat(ex.getMessage()).isEqualTo("倉庫 が見つかりません (id=42)");
+            assertThat(ex.getMessage()).isEqualTo("倉庫 が見つかりません");
+            assertThat(ex.getMessage()).doesNotContain("id=");
+            assertThat(ex.getMessage()).doesNotContain("42");
         }
 
         @Test
-        @DisplayName("of(): 文字列IDでも正しくフォーマットされる")
-        void of_withStringId_createsFormattedMessage() {
+        @DisplayName("of(): 文字列IDでもメッセージに埋め込まれない (OWASP A09)")
+        void of_withStringId_createsFormattedMessageWithoutId() {
             ResourceNotFoundException ex = ResourceNotFoundException.of("USER_NOT_FOUND", "ユーザー", "admin");
 
-            assertThat(ex.getMessage()).isEqualTo("ユーザー が見つかりません (id=admin)");
+            assertThat(ex.getMessage()).isEqualTo("ユーザー が見つかりません");
+            assertThat(ex.getMessage()).doesNotContain("admin");
+            assertThat(ex.getMessage()).doesNotContain("id=");
         }
     }
 

--- a/backend/src/test/java/com/wms/shared/exception/ExceptionClassesTest.java
+++ b/backend/src/test/java/com/wms/shared/exception/ExceptionClassesTest.java
@@ -121,6 +121,16 @@ class ExceptionClassesTest {
             assertThat(ex.getErrorCode()).isEqualTo("CUSTOM_LOCK");
             assertThat(ex.getMessage()).isEqualTo("カスタムメッセージ");
         }
+
+        @Test
+        @DisplayName("standard(): 全Service共通のcode/messageが設定される (内部IDは含まない: OWASP A09)")
+        void standard_createsUnifiedException() {
+            OptimisticLockConflictException ex = OptimisticLockConflictException.standard();
+
+            assertThat(ex.getErrorCode()).isEqualTo("OPTIMISTIC_LOCK_CONFLICT");
+            assertThat(ex.getMessage()).isEqualTo("他のユーザーによる更新が先行しました");
+            assertThat(ex.getMessage()).doesNotContain("id=");
+        }
     }
 
     @Nested

--- a/backend/src/test/java/com/wms/shared/exception/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/wms/shared/exception/GlobalExceptionHandlerTest.java
@@ -97,7 +97,7 @@ class GlobalExceptionHandlerTest {
     @Test
     @DisplayName("OptimisticLockConflictException -> 409 CONFLICT")
     void handleOptimisticLock_optimisticLockConflict_returns409() {
-        var ex = new OptimisticLockConflictException();
+        var ex = OptimisticLockConflictException.standard();
 
         ResponseEntity<ErrorResponse> response = handler.handleOptimisticLock(ex);
 

--- a/backend/src/test/java/com/wms/system/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/wms/system/controller/UserControllerTest.java
@@ -339,7 +339,7 @@ class UserControllerTest {
         @DisplayName("楽観的ロック競合で409を返す")
         void update_conflict_returns409() throws Exception {
             when(userService.update(any(UserService.UpdateUserCommand.class)))
-                    .thenThrow(new OptimisticLockConflictException("OPTIMISTIC_LOCK_CONFLICT", "競合"));
+                    .thenThrow(OptimisticLockConflictException.standard());
 
             UpdateUserRequest request = new UpdateUserRequest()
                     .fullName("名前")
@@ -437,7 +437,7 @@ class UserControllerTest {
         @DisplayName("楽観的ロック競合で409を返す")
         void toggle_conflict_returns409() throws Exception {
             when(userService.toggleActive(eq(1L), eq(false), eq(0), any()))
-                    .thenThrow(new OptimisticLockConflictException("OPTIMISTIC_LOCK_CONFLICT", "競合"));
+                    .thenThrow(OptimisticLockConflictException.standard());
 
             ToggleActiveRequest request = new ToggleActiveRequest()
                     .isActive(false)

--- a/backend/src/test/java/com/wms/system/service/SystemParameterServiceTest.java
+++ b/backend/src/test/java/com/wms/system/service/SystemParameterServiceTest.java
@@ -107,7 +107,9 @@ class SystemParameterServiceTest {
 
         assertThatThrownBy(() -> systemParameterService.updateValue("KEY1", "V2", 3))
                 .isInstanceOf(OptimisticLockConflictException.class)
-                .hasMessageContaining("KEY1");
+                .hasMessage("他のユーザーによる更新が先行しました")
+                .hasMessageNotContaining("key=")
+                .hasMessageNotContaining("KEY1");
     }
 
     @Test

--- a/docs/architecture-design/04-backend-architecture.md
+++ b/docs/architecture-design/04-backend-architecture.md
@@ -432,6 +432,7 @@ public class WarehouseController {
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Slf4j  // log は Lombok @Slf4j により注入
 public class WarehouseService {
 
     private final WarehouseRepository warehouseRepository;
@@ -1280,6 +1281,7 @@ public Warehouse update(Long id, UpdateWarehouseRequest request) {
 
     // フロントエンドから送られたversionとEntityのversionを事前チェック
     if (!warehouse.getVersion().equals(request.version())) {
+        // log は Lombok @Slf4j により注入 (Service クラスに @Slf4j を付与)
         log.info("Warehouse optimistic lock conflict: id={}", id);
         throw OptimisticLockConflictException.standard();
     }

--- a/docs/architecture-design/04-backend-architecture.md
+++ b/docs/architecture-design/04-backend-architecture.md
@@ -467,9 +467,8 @@ public class WarehouseService {
         try {
             return warehouseRepository.save(warehouse);
         } catch (OptimisticLockingFailureException e) {
-            throw new OptimisticLockConflictException(
-                    "OPTIMISTIC_LOCK_CONFLICT",
-                    "他のユーザーによって更新されています。画面を再読み込みしてください");
+            log.info("Warehouse optimistic lock conflict: id={}", id);
+            throw OptimisticLockConflictException.standard();
         }
     }
 
@@ -1281,9 +1280,8 @@ public Warehouse update(Long id, UpdateWarehouseRequest request) {
 
     // フロントエンドから送られたversionとEntityのversionを事前チェック
     if (!warehouse.getVersion().equals(request.version())) {
-        throw new OptimisticLockConflictException(
-                "OPTIMISTIC_LOCK_CONFLICT",
-                "他のユーザーによって更新されています。画面を再読み込みしてください");
+        log.info("Warehouse optimistic lock conflict: id={}", id);
+        throw OptimisticLockConflictException.standard();
     }
 
     warehouse.updateFrom(request);

--- a/docs/architecture-design/08-common-infrastructure.md
+++ b/docs/architecture-design/08-common-infrastructure.md
@@ -1797,7 +1797,8 @@ public WarehouseResponse update(
 
     // クライアントが送信した version と DB の version を比較
     if (!warehouse.getVersion().equals(request.version())) {
-        throw new OptimisticLockConflictException();
+        log.info("Warehouse optimistic lock conflict: id={}", id);
+        throw OptimisticLockConflictException.standard();
     }
 
     // 更新処理

--- a/docs/architecture-design/08-common-infrastructure.md
+++ b/docs/architecture-design/08-common-infrastructure.md
@@ -1797,6 +1797,7 @@ public WarehouseResponse update(
 
     // クライアントが送信した version と DB の version を比較
     if (!warehouse.getVersion().equals(request.version())) {
+        // log は Lombok @Slf4j により注入 (Service クラスに @Slf4j を付与)
         log.info("Warehouse optimistic lock conflict: id={}", id);
         throw OptimisticLockConflictException.standard();
     }

--- a/docs/architecture-design/error-codes.md
+++ b/docs/architecture-design/error-codes.md
@@ -22,7 +22,7 @@
 | `VALIDATION_ERROR` | 400 | 入力バリデーションエラー | 全モジュール |
 | `UNAUTHORIZED` | 401 | 認証エラー | 全モジュール |
 | `FORBIDDEN` | 403 | 権限不足 | 全モジュール |
-| `OPTIMISTIC_LOCK_CONFLICT` | 409 | 楽観的ロック競合 | マスタ管理系 |
+| `OPTIMISTIC_LOCK_CONFLICT` | 409 | 楽観的ロック競合 | 全モジュール (master / system / inbound / inventory / outbound / allocation / returns / batch) |
 | `DUPLICATE_CODE` | 409 | コード重複 | マスタ管理系 |
 | `INVALID_SORT_FIELD` | 400 | 不正なソートフィールド | 一覧取得API |
 | `INTERNAL_SERVER_ERROR` | 500 | サーバー内部エラー | 全モジュール |


### PR DESCRIPTION
Closes #445

## Summary
- OWASP A09 対応: 例外メッセージに含まれていた内部 PK (id/lineId/slipId など) をクライアント返却から除去。
- 追跡性を維持するため、各サービスの例外 throw 直前 / catch ブロックで `log.info` / `log.warn` として内部 id をサーバーログへ出力。
- `ResourceNotFoundException.of(code, resourceName, id)` はシグネチャ互換のため id 引数を残置しつつ、ファクトリ内部で `LOG.info` により id をサーバーログへ出力 (呼び出し元のログ漏れリスクを解消)。
- `OptimisticLockConflictException.standard()` を追加し、全 Service 共通の楽観ロック例外生成をこれに集約 (Area/Building/Location/Partner/Product/Warehouse/User の private optimisticLockConflict() ヘルパを削除)。
- 対象: master (Location/Warehouse/Area/Product/Building/Partner) / system (User) / inbound (InboundSlip) / inventory (Inventory/Stocktake/StocktakeQuery) / outbound (OutboundSlip/Picking) / allocation / returns / batch。
- 各 *ServiceTest のアサーションを `.hasMessageContaining("id=...")` → `.hasMessageNotContaining("id=")` + 業務コード確認に置換。

## Scope limitations

本 PR では下記を対象外としています:

- **report モジュール (14 ファイル) の同種残存**
  - 理由: 当初 #445 の Phase 分割に report モジュールが含まれておらず、14 ファイルの横断修正は本 PR のスコープを超える。
  - 追跡: #472 にて別途対応する。対象ファイル一覧は #472 本文に記載。
- **Service 層の例外ログ出力方式統一 (`ResourceNotFoundException.of` 委譲 vs 手動 `log.info`)**
  - 理由: 全モジュール横断での方式統一 (ロガー名の取り扱い含む) は本 PR のスコープを大きく超えるため、Round 3 指摘 CE-R3-m-2 を別 Issue として切り出し。
  - 追跡: #473 にて案 A/B/C を議論のうえ対応する。

## Round 1 レビュー指摘対応

- **Critical**: 受領 0 件。
- **Major (CE-M-1/DC-M-1 InventoryService, CE-M-2/DC-M-2 InboundSlip/OutboundSlip/ReturnSlip)**: PR 内で対応済み。report 分は #472 へ。
- **Minor (CE-m-1..m-5, SEC-Sug-1/2, SEC-Min-1..3, DC-Mi-1..4, DC-S-1..2)**: 全て PR 内で対応済み。
- **Suggestion (CE-S-1..3, DC-S-3)**: 対応見送り (主観/将来検討領域)。

## Round 3 レビュー指摘対応

- **Minor (CE-R3-m-1)**: `ResourceNotFoundException.of` のロガー名仕様を Javadoc に明記 (PR 内対応)。
- **Minor (CE-R3-m-2)**: Service 層の例外ログ出力方式統一 → #473 に切り出し (条件 a: 全モジュール横断で PR スコープ超過)。
- **Suggestion (CE-R3-S-1)**: `OptimisticLockConflictException` の `@Deprecated` に `since` / `forRemoval=false` を付与 (PR 内対応)。
- **Suggestion (CE-R3-S-2)**: `docs/architecture-design/04-backend-architecture.md` / `08-common-infrastructure.md` のサンプルコードに `@Slf4j` / log 注入のコメントを追記 (PR 内対応)。

## Test coverage (backend JaCoCo)
| 指標 | 値 |
|------|-----|
| C0 (Instructions) | 96.04% (1,248/31,500 missed) |
| C1 (Branches) | 95.43% (79/1,729 missed) |

## Test plan
- [x] `./gradlew :backend:test :backend:jacocoTestReport` グリーン (1842 tests)
- [x] ExceptionClassesTest: `of()` が "id=" / 数値 ID を含まないこと、`standard()` の code/message 確認
- [x] 各 *ServiceTest: 例外メッセージに id が埋め込まれていないこと、業務コードやエラーコードは従来通り返却されることを確認
- [x] Checkstyle / SpotBugs pre-commit / pre-push グリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)