### PR TITLE
fix(report): 例外メッセージから内部 PK を除去 (#472)

### DIFF
--- a/backend/src/main/java/com/wms/report/service/DailySummaryReportService.java
+++ b/backend/src/main/java/com/wms/report/service/DailySummaryReportService.java
@@ -56,8 +56,8 @@ public class DailySummaryReportService {
         boolean batchCompleted = batchExecutionLogRepository
                 .existsByTargetBusinessDateAndStatus(targetBusinessDate, BATCH_STATUS_SUCCESS);
         if (!batchCompleted) {
-            throw new ResourceNotFoundException("BATCH_EXECUTION_NOT_FOUND",
-                    "指定日の日替処理が完了していません: targetBusinessDate=" + targetBusinessDate);
+            throw ResourceNotFoundException.of("BATCH_EXECUTION_NOT_FOUND",
+                    "日替処理結果", targetBusinessDate);
         }
 
         List<DailySummaryReportRow> rows = dailySummaryRecordRepository.findDailySummaryData(targetBusinessDate);

--- a/backend/src/main/java/com/wms/report/service/DeliveryListReportService.java
+++ b/backend/src/main/java/com/wms/report/service/DeliveryListReportService.java
@@ -56,8 +56,7 @@ public class DeliveryListReportService {
         log.info("RPT-14 配送リスト生成開始: warehouseId={}, format={}", warehouseId, format);
 
         Warehouse warehouse = warehouseRepository.findById(warehouseId)
-                .orElseThrow(() -> new ResourceNotFoundException("WAREHOUSE_NOT_FOUND",
-                        "倉庫が見つかりません: warehouseId=" + warehouseId));
+                .orElseThrow(() -> ResourceNotFoundException.of("WAREHOUSE_NOT_FOUND", "倉庫", warehouseId));
 
         String warehouseName = formatWarehouseName(warehouse);
 

--- a/backend/src/main/java/com/wms/report/service/InboundInspectionReportService.java
+++ b/backend/src/main/java/com/wms/report/service/InboundInspectionReportService.java
@@ -49,8 +49,7 @@ public class InboundInspectionReportService {
         log.info("RPT-01 入荷検品レポート生成開始: slipId={}, format={}", slipId, format);
         List<InboundSlipLine> lines = inboundReportRepository.findInspectionReportData(slipId);
         if (lines.isEmpty()) {
-            throw new ResourceNotFoundException("INBOUND_SLIP_NOT_FOUND",
-                    "入荷伝票が見つかりません: slipId=" + slipId);
+            throw ResourceNotFoundException.of("INBOUND_SLIP_NOT_FOUND", "入荷伝票", slipId);
         }
 
         InboundSlip slip = lines.getFirst().getInboundSlip();

--- a/backend/src/main/java/com/wms/report/service/InboundPlanReportService.java
+++ b/backend/src/main/java/com/wms/report/service/InboundPlanReportService.java
@@ -54,8 +54,7 @@ public class InboundPlanReportService {
 
         log.info("RPT-03 入荷予定レポート生成開始: warehouseId={}, format={}", warehouseId, format);
         Warehouse warehouse = warehouseRepository.findById(warehouseId)
-                .orElseThrow(() -> new ResourceNotFoundException("WAREHOUSE_NOT_FOUND",
-                        "倉庫が見つかりません: warehouseId=" + warehouseId));
+                .orElseThrow(() -> ResourceNotFoundException.of("WAREHOUSE_NOT_FOUND", "倉庫", warehouseId));
 
         List<InboundSlipLine> lines = inboundReportRepository.findPlanReportData(
                 warehouseId, plannedDateFrom, plannedDateTo, status, partnerId);

--- a/backend/src/main/java/com/wms/report/service/InboundResultReportService.java
+++ b/backend/src/main/java/com/wms/report/service/InboundResultReportService.java
@@ -57,8 +57,7 @@ public class InboundResultReportService {
 
         log.info("RPT-04 入庫実績レポート生成開始: warehouseId={}, format={}", warehouseId, format);
         Warehouse warehouse = warehouseRepository.findById(warehouseId)
-                .orElseThrow(() -> new ResourceNotFoundException("WAREHOUSE_NOT_FOUND",
-                        "倉庫が見つかりません: warehouseId=" + warehouseId));
+                .orElseThrow(() -> ResourceNotFoundException.of("WAREHOUSE_NOT_FOUND", "倉庫", warehouseId));
 
         OffsetDateTime fromOdt = storedDateFrom != null
                 ? storedDateFrom.atStartOfDay(JST).toOffsetDateTime() : null;

--- a/backend/src/main/java/com/wms/report/service/InventoryCorrectionReportService.java
+++ b/backend/src/main/java/com/wms/report/service/InventoryCorrectionReportService.java
@@ -57,8 +57,7 @@ public class InventoryCorrectionReportService {
 
         log.info("RPT-09 在庫訂正一覧生成開始: warehouseId={}, format={}", warehouseId, format);
         Warehouse warehouse = warehouseRepository.findById(warehouseId)
-                .orElseThrow(() -> new ResourceNotFoundException("WAREHOUSE_NOT_FOUND",
-                        "倉庫が見つかりません: warehouseId=" + warehouseId));
+                .orElseThrow(() -> ResourceNotFoundException.of("WAREHOUSE_NOT_FOUND", "倉庫", warehouseId));
 
         LocalDate effectiveDateFrom = correctionDateFrom != null ? correctionDateFrom
                 : businessDateProvider.today().withDayOfMonth(1);

--- a/backend/src/main/java/com/wms/report/service/InventoryReportService.java
+++ b/backend/src/main/java/com/wms/report/service/InventoryReportService.java
@@ -48,8 +48,7 @@ public class InventoryReportService {
 
         log.info("RPT-07 在庫一覧レポート生成開始: warehouseId={}, format={}", warehouseId, format);
         Warehouse warehouse = warehouseRepository.findById(warehouseId)
-                .orElseThrow(() -> new ResourceNotFoundException("WAREHOUSE_NOT_FOUND",
-                        "倉庫が見つかりません: warehouseId=" + warehouseId));
+                .orElseThrow(() -> ResourceNotFoundException.of("WAREHOUSE_NOT_FOUND", "倉庫", warehouseId));
 
         String unitTypeStr = unitType != null ? unitType.getValue() : null;
         String storageConditionStr = storageCondition != null ? storageCondition.getValue() : null;

--- a/backend/src/main/java/com/wms/report/service/InventoryTransitionReportService.java
+++ b/backend/src/main/java/com/wms/report/service/InventoryTransitionReportService.java
@@ -69,12 +69,10 @@ public class InventoryTransitionReportService {
                 warehouseId, productId, format);
 
         Warehouse warehouse = warehouseRepository.findById(warehouseId)
-                .orElseThrow(() -> new ResourceNotFoundException("WAREHOUSE_NOT_FOUND",
-                        "倉庫が見つかりません: warehouseId=" + warehouseId));
+                .orElseThrow(() -> ResourceNotFoundException.of("WAREHOUSE_NOT_FOUND", "倉庫", warehouseId));
 
         Product product = productRepository.findById(productId)
-                .orElseThrow(() -> new ResourceNotFoundException("PRODUCT_NOT_FOUND",
-                        "商品が見つかりません: productId=" + productId));
+                .orElseThrow(() -> ResourceNotFoundException.of("PRODUCT_NOT_FOUND", "商品", productId));
 
         LocalDate effectiveDateFrom = dateFrom != null ? dateFrom
                 : businessDateProvider.today().withDayOfMonth(1);

--- a/backend/src/main/java/com/wms/report/service/PickingInstructionReportService.java
+++ b/backend/src/main/java/com/wms/report/service/PickingInstructionReportService.java
@@ -53,12 +53,10 @@ public class PickingInstructionReportService {
                 pickingInstructionId, format);
 
         PickingInstruction instruction = pickingInstructionRepository.findById(pickingInstructionId)
-                .orElseThrow(() -> new ResourceNotFoundException("PICKING_NOT_FOUND",
-                        "ピッキング指示が見つかりません: pickingInstructionId=" + pickingInstructionId));
+                .orElseThrow(() -> ResourceNotFoundException.of("PICKING_NOT_FOUND", "ピッキング指示", pickingInstructionId));
 
         Warehouse warehouse = warehouseRepository.findById(instruction.getWarehouseId())
-                .orElseThrow(() -> new ResourceNotFoundException("WAREHOUSE_NOT_FOUND",
-                        "倉庫が見つかりません: warehouseId=" + instruction.getWarehouseId()));
+                .orElseThrow(() -> ResourceNotFoundException.of("WAREHOUSE_NOT_FOUND", "倉庫", instruction.getWarehouseId()));
 
         String warehouseName = formatWarehouseName(warehouse);
 

--- a/backend/src/main/java/com/wms/report/service/ReturnsReportService.java
+++ b/backend/src/main/java/com/wms/report/service/ReturnsReportService.java
@@ -74,8 +74,7 @@ public class ReturnsReportService {
                 productId, partnerId, returnReason, format);
 
         Warehouse warehouse = warehouseRepository.findById(warehouseId)
-                .orElseThrow(() -> new ResourceNotFoundException("WAREHOUSE_NOT_FOUND",
-                        "倉庫が見つかりません: warehouseId=" + warehouseId));
+                .orElseThrow(() -> ResourceNotFoundException.of("WAREHOUSE_NOT_FOUND", "倉庫", warehouseId));
 
         String warehouseName = formatWarehouseName(warehouse);
 

--- a/backend/src/main/java/com/wms/report/service/ShippingInspectionReportService.java
+++ b/backend/src/main/java/com/wms/report/service/ShippingInspectionReportService.java
@@ -51,12 +51,10 @@ public class ShippingInspectionReportService {
         log.info("RPT-13 出荷検品レポート生成開始: slipId={}, format={}", slipId, format);
 
         OutboundSlip slip = outboundSlipRepository.findById(slipId)
-                .orElseThrow(() -> new ResourceNotFoundException("OUTBOUND_SLIP_NOT_FOUND",
-                        "出荷伝票が見つかりません: slipId=" + slipId));
+                .orElseThrow(() -> ResourceNotFoundException.of("OUTBOUND_SLIP_NOT_FOUND", "出荷伝票", slipId));
 
         Warehouse warehouse = warehouseRepository.findById(slip.getWarehouseId())
-                .orElseThrow(() -> new ResourceNotFoundException("WAREHOUSE_NOT_FOUND",
-                        "倉庫が見つかりません: warehouseId=" + slip.getWarehouseId()));
+                .orElseThrow(() -> ResourceNotFoundException.of("WAREHOUSE_NOT_FOUND", "倉庫", slip.getWarehouseId()));
 
         String warehouseName = formatWarehouseName(warehouse);
 

--- a/backend/src/main/java/com/wms/report/service/StocktakeListReportService.java
+++ b/backend/src/main/java/com/wms/report/service/StocktakeListReportService.java
@@ -66,11 +66,9 @@ public class StocktakeListReportService {
 
         if (stocktakeId != null) {
             StocktakeHeader header = stocktakeHeaderRepository.findById(stocktakeId)
-                    .orElseThrow(() -> new ResourceNotFoundException("STOCKTAKE_NOT_FOUND",
-                            "棚卸が見つかりません: stocktakeId=" + stocktakeId));
+                    .orElseThrow(() -> ResourceNotFoundException.of("STOCKTAKE_NOT_FOUND", "棚卸", stocktakeId));
             Warehouse warehouse = warehouseRepository.findById(header.getWarehouseId())
-                    .orElseThrow(() -> new ResourceNotFoundException("WAREHOUSE_NOT_FOUND",
-                            "倉庫が見つかりません: warehouseId=" + header.getWarehouseId()));
+                    .orElseThrow(() -> ResourceNotFoundException.of("WAREHOUSE_NOT_FOUND", "倉庫", header.getWarehouseId()));
             warehouseName = formatWarehouseName(warehouse);
             conditionsSummary = "棚卸番号: " + header.getStocktakeNumber();
             if (header.getTargetDescription() != null) {
@@ -79,11 +77,9 @@ public class StocktakeListReportService {
             rows = stocktakeReportRepository.findStocktakeListByStocktakeId(stocktakeId);
         } else {
             Building building = buildingRepository.findById(buildingId)
-                    .orElseThrow(() -> new ResourceNotFoundException("BUILDING_NOT_FOUND",
-                            "棟が見つかりません: buildingId=" + buildingId));
+                    .orElseThrow(() -> ResourceNotFoundException.of("BUILDING_NOT_FOUND", "棟", buildingId));
             Warehouse warehouse = warehouseRepository.findById(building.getWarehouseId())
-                    .orElseThrow(() -> new ResourceNotFoundException("WAREHOUSE_NOT_FOUND",
-                            "倉庫が見つかりません: warehouseId=" + building.getWarehouseId()));
+                    .orElseThrow(() -> ResourceNotFoundException.of("WAREHOUSE_NOT_FOUND", "倉庫", building.getWarehouseId()));
             warehouseName = formatWarehouseName(warehouse);
             conditionsSummary = "棟: " + building.getBuildingName() + " (" + building.getBuildingCode() + ") [プレビュー]";
             rows = stocktakeReportRepository.findStocktakeListByBuildingId(buildingId, areaId);

--- a/backend/src/main/java/com/wms/report/service/StocktakeResultReportService.java
+++ b/backend/src/main/java/com/wms/report/service/StocktakeResultReportService.java
@@ -58,12 +58,10 @@ public class StocktakeResultReportService {
         log.info("RPT-11 棚卸結果レポート生成開始: stocktakeId={}, format={}", stocktakeId, format);
 
         StocktakeHeader header = stocktakeHeaderRepository.findById(stocktakeId)
-                .orElseThrow(() -> new ResourceNotFoundException("STOCKTAKE_NOT_FOUND",
-                        "棚卸が見つかりません: stocktakeId=" + stocktakeId));
+                .orElseThrow(() -> ResourceNotFoundException.of("STOCKTAKE_NOT_FOUND", "棚卸", stocktakeId));
 
         Warehouse warehouse = warehouseRepository.findById(header.getWarehouseId())
-                .orElseThrow(() -> new ResourceNotFoundException("WAREHOUSE_NOT_FOUND",
-                        "倉庫が見つかりません: warehouseId=" + header.getWarehouseId()));
+                .orElseThrow(() -> ResourceNotFoundException.of("WAREHOUSE_NOT_FOUND", "倉庫", header.getWarehouseId()));
 
         String warehouseName = formatWarehouseName(warehouse);
 

--- a/backend/src/main/java/com/wms/report/service/UnreceivedConfirmedReportService.java
+++ b/backend/src/main/java/com/wms/report/service/UnreceivedConfirmedReportService.java
@@ -49,8 +49,7 @@ public class UnreceivedConfirmedReportService {
         log.info("RPT-06 未入荷リスト（確定）生成開始: warehouseId={}, batchBusinessDate={}, format={}",
                 warehouseId, batchBusinessDate, format);
         Warehouse warehouse = warehouseRepository.findById(warehouseId)
-                .orElseThrow(() -> new ResourceNotFoundException("WAREHOUSE_NOT_FOUND",
-                        "倉庫が見つかりません: warehouseId=" + warehouseId));
+                .orElseThrow(() -> ResourceNotFoundException.of("WAREHOUSE_NOT_FOUND", "倉庫", warehouseId));
 
         List<UnreceivedListRecord> records = unreceivedListRecordRepository
                 .findByBatchBusinessDateAndWarehouseCode(batchBusinessDate, warehouse.getWarehouseCode());

--- a/backend/src/main/java/com/wms/report/service/UnreceivedRealtimeReportService.java
+++ b/backend/src/main/java/com/wms/report/service/UnreceivedRealtimeReportService.java
@@ -57,8 +57,7 @@ public class UnreceivedRealtimeReportService {
         log.info("RPT-05 未入荷リスト（リアルタイム）生成開始: warehouseId={}, asOfDate={}, format={}",
                 warehouseId, asOfDate, format);
         Warehouse warehouse = warehouseRepository.findById(warehouseId)
-                .orElseThrow(() -> new ResourceNotFoundException("WAREHOUSE_NOT_FOUND",
-                        "倉庫が見つかりません: warehouseId=" + warehouseId));
+                .orElseThrow(() -> ResourceNotFoundException.of("WAREHOUSE_NOT_FOUND", "倉庫", warehouseId));
 
         LocalDate effectiveDate = asOfDate != null ? asOfDate : businessDateProvider.today();
 

--- a/backend/src/main/java/com/wms/report/service/UnshippedConfirmedReportService.java
+++ b/backend/src/main/java/com/wms/report/service/UnshippedConfirmedReportService.java
@@ -51,8 +51,7 @@ public class UnshippedConfirmedReportService {
                 warehouseId, batchBusinessDate, format);
 
         Warehouse warehouse = warehouseRepository.findById(warehouseId)
-                .orElseThrow(() -> new ResourceNotFoundException("WAREHOUSE_NOT_FOUND",
-                        "倉庫が見つかりません: warehouseId=" + warehouseId));
+                .orElseThrow(() -> ResourceNotFoundException.of("WAREHOUSE_NOT_FOUND", "倉庫", warehouseId));
 
         String warehouseName = formatWarehouseName(warehouse);
 

--- a/backend/src/main/java/com/wms/report/service/UnshippedRealtimeReportService.java
+++ b/backend/src/main/java/com/wms/report/service/UnshippedRealtimeReportService.java
@@ -52,8 +52,7 @@ public class UnshippedRealtimeReportService {
                 warehouseId, asOfDate, format);
 
         Warehouse warehouse = warehouseRepository.findById(warehouseId)
-                .orElseThrow(() -> new ResourceNotFoundException("WAREHOUSE_NOT_FOUND",
-                        "倉庫が見つかりません: warehouseId=" + warehouseId));
+                .orElseThrow(() -> ResourceNotFoundException.of("WAREHOUSE_NOT_FOUND", "倉庫", warehouseId));
 
         String warehouseName = formatWarehouseName(warehouse);
 

--- a/backend/src/main/java/com/wms/shared/exception/ResourceNotFoundException.java
+++ b/backend/src/main/java/com/wms/shared/exception/ResourceNotFoundException.java
@@ -39,6 +39,11 @@ public final class ResourceNotFoundException extends WmsException {
      * resourceName はロガー名に依らず一意に grep 可能なため、通常運用では本ファクトリの
      * 利用で差し支えない (MDC の traceId も併用される)。</p>
      *
+     * <p><strong>id 引数の安全性:</strong> {@code id} は信頼できる内部 PK (Long 等の数値型) のみを
+     * 渡すこと。ユーザー入力由来の文字列を直接渡すと、{@code \r\n} を含む値で偽ログ行が挿入される
+     * (CRLF ログインジェクション) リスクがある。文字列 ID をログ出力する場合は呼び出し元で
+     * 改行文字をサニタイズしてから渡すこと。</p>
+     *
      * @param id 内部 PK — メッセージには埋め込まれず、ログ出力専用。
      */
     public static ResourceNotFoundException of(String errorCode, String resourceName, Object id) {

--- a/backend/src/main/java/com/wms/shared/exception/ResourceNotFoundException.java
+++ b/backend/src/main/java/com/wms/shared/exception/ResourceNotFoundException.java
@@ -44,6 +44,11 @@ public final class ResourceNotFoundException extends WmsException {
      * (CRLF ログインジェクション) リスクがある。文字列 ID をログ出力する場合は呼び出し元で
      * 改行文字をサニタイズしてから渡すこと。</p>
      *
+     * @param errorCode エラーコード文字列 (例: {@code "WAREHOUSE_NOT_FOUND"})。
+     *                  error-codes.md に定義されたリテラルを直接指定すること。
+     * @param resourceName リソース種別名 (例: {@code "倉庫"}, {@code "棚卸"})。
+     *                     コードリテラルのみ許容。ユーザー入力由来の値を渡してはならない
+     *                     (ログインジェクション・メッセージ汚染の防止)。
      * @param id 内部 PK — メッセージには埋め込まれず、ログ出力専用。
      */
     public static ResourceNotFoundException of(String errorCode, String resourceName, Object id) {

--- a/backend/src/test/java/com/wms/report/service/DailySummaryReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/DailySummaryReportServiceTest.java
@@ -23,8 +23,9 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import java.time.LocalDate;
 import java.util.List;
 
+import static com.wms.shared.exception.ResourceNotFoundAssertions.assertResourceNotFound;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
@@ -288,10 +289,8 @@ class DailySummaryReportServiceTest {
             when(batchExecutionLogRepository.existsByTargetBusinessDateAndStatus(TARGET_DATE, DailySummaryReportService.BATCH_STATUS_SUCCESS))
                     .thenReturn(false);
 
-            assertThatThrownBy(() -> service.generate(TARGET_DATE, ReportFormat.JSON))
-                    .isInstanceOf(ResourceNotFoundException.class)
-                    .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
-                            .isEqualTo("BATCH_EXECUTION_NOT_FOUND"));
+            Throwable thrown = catchThrowable(() -> service.generate(TARGET_DATE, ReportFormat.JSON));
+            assertResourceNotFound(thrown, "BATCH_EXECUTION_NOT_FOUND", "日替処理結果");
         }
     }
 }

--- a/backend/src/test/java/com/wms/report/service/DeliveryListReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/DeliveryListReportServiceTest.java
@@ -493,6 +493,9 @@ class DeliveryListReportServiceTest {
 
             assertThatThrownBy(() -> service.generate(999L, null, null, null, null, ReportFormat.JSON))
                     .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageContaining("倉庫 が見つかりません")
+                    .hasMessageNotContaining("id=")
+                    .hasMessageNotContaining("999")
                     .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
                             .isEqualTo("WAREHOUSE_NOT_FOUND"));
         }

--- a/backend/src/test/java/com/wms/report/service/DeliveryListReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/DeliveryListReportServiceTest.java
@@ -8,7 +8,6 @@ import com.wms.master.repository.WarehouseRepository;
 import com.wms.report.repository.OutboundReportRepository;
 import com.wms.report.repository.projection.DeliveryListHeaderRow;
 import com.wms.report.repository.projection.DeliveryListLineRow;
-import com.wms.shared.exception.ResourceNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -26,8 +25,9 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
+import static com.wms.shared.exception.ResourceNotFoundAssertions.assertResourceNotFound;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
@@ -491,13 +491,9 @@ class DeliveryListReportServiceTest {
         void generate_warehouseNotFound_throwsException() {
             when(warehouseRepository.findById(999L)).thenReturn(Optional.empty());
 
-            assertThatThrownBy(() -> service.generate(999L, null, null, null, null, ReportFormat.JSON))
-                    .isInstanceOf(ResourceNotFoundException.class)
-                    .hasMessageContaining("倉庫 が見つかりません")
-                    .hasMessageNotContaining("id=")
-                    .hasMessageNotContaining("999")
-                    .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
-                            .isEqualTo("WAREHOUSE_NOT_FOUND"));
+            Throwable thrown = catchThrowable(
+                    () -> service.generate(999L, null, null, null, null, ReportFormat.JSON));
+            assertResourceNotFound(thrown, "WAREHOUSE_NOT_FOUND", "倉庫");
         }
     }
 

--- a/backend/src/test/java/com/wms/report/service/InboundInspectionReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/InboundInspectionReportServiceTest.java
@@ -24,7 +24,6 @@ import java.util.List;
 
 import static com.wms.shared.exception.ResourceNotFoundAssertions.assertResourceNotFound;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;

--- a/backend/src/test/java/com/wms/report/service/InboundInspectionReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/InboundInspectionReportServiceTest.java
@@ -300,6 +300,9 @@ class InboundInspectionReportServiceTest {
 
             assertThatThrownBy(() -> service.generate(999L, ReportFormat.JSON))
                     .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageContaining("入荷伝票 が見つかりません")
+                    .hasMessageNotContaining("id=")
+                    .hasMessageNotContaining("999")
                     .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
                             .isEqualTo("INBOUND_SLIP_NOT_FOUND"));
         }

--- a/backend/src/test/java/com/wms/report/service/InboundInspectionReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/InboundInspectionReportServiceTest.java
@@ -7,7 +7,6 @@ import com.wms.inbound.entity.InboundSlipLine;
 import com.wms.master.entity.Product;
 import com.wms.master.repository.ProductRepository;
 import com.wms.report.repository.InboundReportRepository;
-import com.wms.shared.exception.ResourceNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -23,8 +22,10 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import java.time.LocalDate;
 import java.util.List;
 
+import static com.wms.shared.exception.ResourceNotFoundAssertions.assertResourceNotFound;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
@@ -298,13 +299,8 @@ class InboundInspectionReportServiceTest {
         void generate_slipNotFound_throwsResourceNotFoundException() {
             when(inboundReportRepository.findInspectionReportData(999L)).thenReturn(List.of());
 
-            assertThatThrownBy(() -> service.generate(999L, ReportFormat.JSON))
-                    .isInstanceOf(ResourceNotFoundException.class)
-                    .hasMessageContaining("入荷伝票 が見つかりません")
-                    .hasMessageNotContaining("id=")
-                    .hasMessageNotContaining("999")
-                    .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
-                            .isEqualTo("INBOUND_SLIP_NOT_FOUND"));
+            Throwable thrown = catchThrowable(() -> service.generate(999L, ReportFormat.JSON));
+            assertResourceNotFound(thrown, "INBOUND_SLIP_NOT_FOUND", "入荷伝票");
         }
     }
 }

--- a/backend/src/test/java/com/wms/report/service/InboundPlanReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/InboundPlanReportServiceTest.java
@@ -340,6 +340,9 @@ class InboundPlanReportServiceTest {
 
             assertThatThrownBy(() -> service.generate(999L, null, null, null, null, ReportFormat.JSON))
                     .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageContaining("倉庫 が見つかりません")
+                    .hasMessageNotContaining("id=")
+                    .hasMessageNotContaining("999")
                     .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
                             .isEqualTo("WAREHOUSE_NOT_FOUND"));
         }

--- a/backend/src/test/java/com/wms/report/service/InboundPlanReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/InboundPlanReportServiceTest.java
@@ -9,7 +9,6 @@ import com.wms.master.entity.Warehouse;
 import com.wms.master.repository.ProductRepository;
 import com.wms.master.repository.WarehouseRepository;
 import com.wms.report.repository.InboundReportRepository;
-import com.wms.shared.exception.ResourceNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -27,8 +26,9 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
+import static com.wms.shared.exception.ResourceNotFoundAssertions.assertResourceNotFound;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.verify;
@@ -338,13 +338,9 @@ class InboundPlanReportServiceTest {
         void generate_warehouseNotFound_throwsException() {
             when(warehouseRepository.findById(999L)).thenReturn(Optional.empty());
 
-            assertThatThrownBy(() -> service.generate(999L, null, null, null, null, ReportFormat.JSON))
-                    .isInstanceOf(ResourceNotFoundException.class)
-                    .hasMessageContaining("倉庫 が見つかりません")
-                    .hasMessageNotContaining("id=")
-                    .hasMessageNotContaining("999")
-                    .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
-                            .isEqualTo("WAREHOUSE_NOT_FOUND"));
+            Throwable thrown = catchThrowable(
+                    () -> service.generate(999L, null, null, null, null, ReportFormat.JSON));
+            assertResourceNotFound(thrown, "WAREHOUSE_NOT_FOUND", "倉庫");
         }
     }
 }

--- a/backend/src/test/java/com/wms/report/service/InboundResultReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/InboundResultReportServiceTest.java
@@ -389,6 +389,9 @@ class InboundResultReportServiceTest {
 
             assertThatThrownBy(() -> service.generate(999L, null, null, null, ReportFormat.JSON))
                     .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageContaining("倉庫 が見つかりません")
+                    .hasMessageNotContaining("id=")
+                    .hasMessageNotContaining("999")
                     .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
                             .isEqualTo("WAREHOUSE_NOT_FOUND"));
         }

--- a/backend/src/test/java/com/wms/report/service/InboundResultReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/InboundResultReportServiceTest.java
@@ -9,7 +9,6 @@ import com.wms.master.entity.Warehouse;
 import com.wms.master.repository.ProductRepository;
 import com.wms.master.repository.WarehouseRepository;
 import com.wms.report.repository.InboundReportRepository;
-import com.wms.shared.exception.ResourceNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -29,8 +28,9 @@ import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 
+import static com.wms.shared.exception.ResourceNotFoundAssertions.assertResourceNotFound;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.verify;
@@ -387,13 +387,9 @@ class InboundResultReportServiceTest {
         void generate_warehouseNotFound_throwsException() {
             when(warehouseRepository.findById(999L)).thenReturn(Optional.empty());
 
-            assertThatThrownBy(() -> service.generate(999L, null, null, null, ReportFormat.JSON))
-                    .isInstanceOf(ResourceNotFoundException.class)
-                    .hasMessageContaining("倉庫 が見つかりません")
-                    .hasMessageNotContaining("id=")
-                    .hasMessageNotContaining("999")
-                    .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
-                            .isEqualTo("WAREHOUSE_NOT_FOUND"));
+            Throwable thrown = catchThrowable(
+                    () -> service.generate(999L, null, null, null, ReportFormat.JSON));
+            assertResourceNotFound(thrown, "WAREHOUSE_NOT_FOUND", "倉庫");
         }
     }
 }

--- a/backend/src/test/java/com/wms/report/service/InventoryCorrectionReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/InventoryCorrectionReportServiceTest.java
@@ -6,7 +6,6 @@ import com.wms.inventory.entity.InventoryMovement;
 import com.wms.master.entity.Warehouse;
 import com.wms.master.repository.WarehouseRepository;
 import com.wms.report.repository.InventoryMovementReportRepository;
-import com.wms.shared.exception.ResourceNotFoundException;
 import com.wms.shared.util.BusinessDateProvider;
 import com.wms.system.entity.User;
 import com.wms.system.repository.UserRepository;
@@ -30,7 +29,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static com.wms.shared.exception.ResourceNotFoundAssertions.assertResourceNotFound;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
@@ -207,13 +207,9 @@ class InventoryCorrectionReportServiceTest {
         void generate_warehouseNotFound_throwsException() {
             when(warehouseRepository.findById(999L)).thenReturn(Optional.empty());
 
-            assertThatThrownBy(() -> service.generate(999L, null, null, ReportFormat.JSON))
-                    .isInstanceOf(ResourceNotFoundException.class)
-                    .hasMessageContaining("倉庫 が見つかりません")
-                    .hasMessageNotContaining("id=")
-                    .hasMessageNotContaining("999")
-                    .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
-                            .isEqualTo("WAREHOUSE_NOT_FOUND"));
+            Throwable thrown = catchThrowable(
+                    () -> service.generate(999L, null, null, ReportFormat.JSON));
+            assertResourceNotFound(thrown, "WAREHOUSE_NOT_FOUND", "倉庫");
         }
     }
 }

--- a/backend/src/test/java/com/wms/report/service/InventoryCorrectionReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/InventoryCorrectionReportServiceTest.java
@@ -209,6 +209,9 @@ class InventoryCorrectionReportServiceTest {
 
             assertThatThrownBy(() -> service.generate(999L, null, null, ReportFormat.JSON))
                     .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageContaining("倉庫 が見つかりません")
+                    .hasMessageNotContaining("id=")
+                    .hasMessageNotContaining("999")
                     .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
                             .isEqualTo("WAREHOUSE_NOT_FOUND"));
         }

--- a/backend/src/test/java/com/wms/report/service/InventoryCorrectionReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/InventoryCorrectionReportServiceTest.java
@@ -28,8 +28,8 @@ import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static com.wms.shared.exception.ResourceNotFoundAssertions.assertResourceNotFound;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;

--- a/backend/src/test/java/com/wms/report/service/InventoryReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/InventoryReportServiceTest.java
@@ -252,6 +252,9 @@ class InventoryReportServiceTest {
 
             assertThatThrownBy(() -> service.generate(999L, null, null, null, null, ReportFormat.JSON))
                     .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageContaining("倉庫 が見つかりません")
+                    .hasMessageNotContaining("id=")
+                    .hasMessageNotContaining("999")
                     .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
                             .isEqualTo("WAREHOUSE_NOT_FOUND"));
         }

--- a/backend/src/test/java/com/wms/report/service/InventoryReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/InventoryReportServiceTest.java
@@ -25,8 +25,8 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static com.wms.shared.exception.ResourceNotFoundAssertions.assertResourceNotFound;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;

--- a/backend/src/test/java/com/wms/report/service/InventoryReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/InventoryReportServiceTest.java
@@ -8,7 +8,6 @@ import com.wms.master.entity.Warehouse;
 import com.wms.master.repository.WarehouseRepository;
 import com.wms.report.repository.InventoryReportRepository;
 import com.wms.report.repository.projection.InventoryReportRow;
-import com.wms.shared.exception.ResourceNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -27,7 +26,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static com.wms.shared.exception.ResourceNotFoundAssertions.assertResourceNotFound;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
@@ -250,13 +250,9 @@ class InventoryReportServiceTest {
         void generate_warehouseNotFound_throwsException() {
             when(warehouseRepository.findById(999L)).thenReturn(Optional.empty());
 
-            assertThatThrownBy(() -> service.generate(999L, null, null, null, null, ReportFormat.JSON))
-                    .isInstanceOf(ResourceNotFoundException.class)
-                    .hasMessageContaining("倉庫 が見つかりません")
-                    .hasMessageNotContaining("id=")
-                    .hasMessageNotContaining("999")
-                    .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
-                            .isEqualTo("WAREHOUSE_NOT_FOUND"));
+            Throwable thrown = catchThrowable(
+                    () -> service.generate(999L, null, null, null, null, ReportFormat.JSON));
+            assertResourceNotFound(thrown, "WAREHOUSE_NOT_FOUND", "倉庫");
         }
     }
 }

--- a/backend/src/test/java/com/wms/report/service/InventoryTransitionReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/InventoryTransitionReportServiceTest.java
@@ -255,6 +255,9 @@ class InventoryTransitionReportServiceTest {
 
             assertThatThrownBy(() -> service.generate(999L, 100L, null, null, ReportFormat.JSON))
                     .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageContaining("倉庫 が見つかりません")
+                    .hasMessageNotContaining("id=")
+                    .hasMessageNotContaining("999")
                     .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
                             .isEqualTo("WAREHOUSE_NOT_FOUND"));
         }
@@ -267,6 +270,9 @@ class InventoryTransitionReportServiceTest {
 
             assertThatThrownBy(() -> service.generate(1L, 999L, null, null, ReportFormat.JSON))
                     .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageContaining("商品 が見つかりません")
+                    .hasMessageNotContaining("id=")
+                    .hasMessageNotContaining("999")
                     .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
                             .isEqualTo("PRODUCT_NOT_FOUND"));
         }

--- a/backend/src/test/java/com/wms/report/service/InventoryTransitionReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/InventoryTransitionReportServiceTest.java
@@ -28,8 +28,8 @@ import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static com.wms.shared.exception.ResourceNotFoundAssertions.assertResourceNotFound;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;

--- a/backend/src/test/java/com/wms/report/service/InventoryTransitionReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/InventoryTransitionReportServiceTest.java
@@ -8,7 +8,6 @@ import com.wms.master.entity.Warehouse;
 import com.wms.master.repository.ProductRepository;
 import com.wms.master.repository.WarehouseRepository;
 import com.wms.report.repository.InventoryMovementReportRepository;
-import com.wms.shared.exception.ResourceNotFoundException;
 import com.wms.shared.util.BusinessDateProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -30,7 +29,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static com.wms.shared.exception.ResourceNotFoundAssertions.assertResourceNotFound;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
@@ -253,28 +253,20 @@ class InventoryTransitionReportServiceTest {
         void generate_warehouseNotFound_throwsException() {
             when(warehouseRepository.findById(999L)).thenReturn(Optional.empty());
 
-            assertThatThrownBy(() -> service.generate(999L, 100L, null, null, ReportFormat.JSON))
-                    .isInstanceOf(ResourceNotFoundException.class)
-                    .hasMessageContaining("倉庫 が見つかりません")
-                    .hasMessageNotContaining("id=")
-                    .hasMessageNotContaining("999")
-                    .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
-                            .isEqualTo("WAREHOUSE_NOT_FOUND"));
+            Throwable thrown = catchThrowable(
+                    () -> service.generate(999L, 100L, null, null, ReportFormat.JSON));
+            assertResourceNotFound(thrown, "WAREHOUSE_NOT_FOUND", "倉庫");
         }
 
         @Test
-        @DisplayName("商品が存在しない場合は ResourceNotFoundException")
+        @DisplayName("商品が存在しない場合は ResourceNotFoundException (連鎖 lookup: 倉庫 1L 成功 → 商品 999L 失敗)")
         void generate_productNotFound_throwsException() {
             when(warehouseRepository.findById(1L)).thenReturn(Optional.of(warehouse));
             when(productRepository.findById(999L)).thenReturn(Optional.empty());
 
-            assertThatThrownBy(() -> service.generate(1L, 999L, null, null, ReportFormat.JSON))
-                    .isInstanceOf(ResourceNotFoundException.class)
-                    .hasMessageContaining("商品 が見つかりません")
-                    .hasMessageNotContaining("id=")
-                    .hasMessageNotContaining("999")
-                    .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
-                            .isEqualTo("PRODUCT_NOT_FOUND"));
+            Throwable thrown = catchThrowable(
+                    () -> service.generate(1L, 999L, null, null, ReportFormat.JSON));
+            assertResourceNotFound(thrown, "PRODUCT_NOT_FOUND", "商品");
         }
     }
 }

--- a/backend/src/test/java/com/wms/report/service/PickingInstructionReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/PickingInstructionReportServiceTest.java
@@ -25,8 +25,8 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static com.wms.shared.exception.ResourceNotFoundAssertions.assertResourceNotFound;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;

--- a/backend/src/test/java/com/wms/report/service/PickingInstructionReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/PickingInstructionReportServiceTest.java
@@ -8,7 +8,6 @@ import com.wms.outbound.entity.PickingInstruction;
 import com.wms.outbound.repository.PickingInstructionRepository;
 import com.wms.report.repository.OutboundReportRepository;
 import com.wms.report.repository.projection.PickingInstructionRow;
-import com.wms.shared.exception.ResourceNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -27,7 +26,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static com.wms.shared.exception.ResourceNotFoundAssertions.assertResourceNotFound;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
@@ -290,17 +290,12 @@ class PickingInstructionReportServiceTest {
         void generate_pickingNotFound_throwsException() {
             when(pickingInstructionRepository.findById(999L)).thenReturn(Optional.empty());
 
-            assertThatThrownBy(() -> service.generate(999L, ReportFormat.JSON))
-                    .isInstanceOf(ResourceNotFoundException.class)
-                    .hasMessageContaining("ピッキング指示 が見つかりません")
-                    .hasMessageNotContaining("id=")
-                    .hasMessageNotContaining("999")
-                    .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
-                            .isEqualTo("PICKING_NOT_FOUND"));
+            Throwable thrown = catchThrowable(() -> service.generate(999L, ReportFormat.JSON));
+            assertResourceNotFound(thrown, "PICKING_NOT_FOUND", "ピッキング指示");
         }
 
         @Test
-        @DisplayName("倉庫が存在しない場合はResourceNotFoundException")
+        @DisplayName("倉庫が存在しない場合はResourceNotFoundException (連鎖 lookup: ピッキング指示 1L 成功 → 倉庫 999L 失敗)")
         void generate_warehouseNotFound_throwsException() {
             PickingInstruction instruction = PickingInstruction.builder()
                     .id(1L)
@@ -311,13 +306,8 @@ class PickingInstructionReportServiceTest {
             when(pickingInstructionRepository.findById(1L)).thenReturn(Optional.of(instruction));
             when(warehouseRepository.findById(999L)).thenReturn(Optional.empty());
 
-            assertThatThrownBy(() -> service.generate(1L, ReportFormat.JSON))
-                    .isInstanceOf(ResourceNotFoundException.class)
-                    .hasMessageContaining("倉庫 が見つかりません")
-                    .hasMessageNotContaining("id=")
-                    .hasMessageNotContaining("999")
-                    .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
-                            .isEqualTo("WAREHOUSE_NOT_FOUND"));
+            Throwable thrown = catchThrowable(() -> service.generate(1L, ReportFormat.JSON));
+            assertResourceNotFound(thrown, "WAREHOUSE_NOT_FOUND", "倉庫");
         }
     }
 }

--- a/backend/src/test/java/com/wms/report/service/PickingInstructionReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/PickingInstructionReportServiceTest.java
@@ -292,6 +292,9 @@ class PickingInstructionReportServiceTest {
 
             assertThatThrownBy(() -> service.generate(999L, ReportFormat.JSON))
                     .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageContaining("ピッキング指示 が見つかりません")
+                    .hasMessageNotContaining("id=")
+                    .hasMessageNotContaining("999")
                     .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
                             .isEqualTo("PICKING_NOT_FOUND"));
         }
@@ -310,6 +313,9 @@ class PickingInstructionReportServiceTest {
 
             assertThatThrownBy(() -> service.generate(1L, ReportFormat.JSON))
                     .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageContaining("倉庫 が見つかりません")
+                    .hasMessageNotContaining("id=")
+                    .hasMessageNotContaining("999")
                     .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
                             .isEqualTo("WAREHOUSE_NOT_FOUND"));
         }

--- a/backend/src/test/java/com/wms/report/service/ReturnsReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/ReturnsReportServiceTest.java
@@ -8,7 +8,6 @@ import com.wms.master.entity.Warehouse;
 import com.wms.master.repository.WarehouseRepository;
 import com.wms.report.repository.ReturnsReportRepository;
 import com.wms.report.repository.projection.ReturnsReportRow;
-import com.wms.shared.exception.ResourceNotFoundException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -30,7 +29,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static com.wms.shared.exception.ResourceNotFoundAssertions.assertResourceNotFound;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
@@ -460,14 +460,9 @@ class ReturnsReportServiceTest {
         void generate_warehouseNotFound_throwsException() {
             when(warehouseRepository.findById(999L)).thenReturn(Optional.empty());
 
-            assertThatThrownBy(() -> service.generate(
-                    999L, null, null, null, null, null, null, ReportFormat.JSON))
-                    .isInstanceOf(ResourceNotFoundException.class)
-                    .hasMessageContaining("倉庫 が見つかりません")
-                    .hasMessageNotContaining("id=")
-                    .hasMessageNotContaining("999")
-                    .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
-                            .isEqualTo("WAREHOUSE_NOT_FOUND"));
+            Throwable thrown = catchThrowable(() -> service.generate(
+                    999L, null, null, null, null, null, null, ReportFormat.JSON));
+            assertResourceNotFound(thrown, "WAREHOUSE_NOT_FOUND", "倉庫");
         }
     }
 

--- a/backend/src/test/java/com/wms/report/service/ReturnsReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/ReturnsReportServiceTest.java
@@ -463,6 +463,9 @@ class ReturnsReportServiceTest {
             assertThatThrownBy(() -> service.generate(
                     999L, null, null, null, null, null, null, ReportFormat.JSON))
                     .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageContaining("倉庫 が見つかりません")
+                    .hasMessageNotContaining("id=")
+                    .hasMessageNotContaining("999")
                     .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
                             .isEqualTo("WAREHOUSE_NOT_FOUND"));
         }

--- a/backend/src/test/java/com/wms/report/service/ReturnsReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/ReturnsReportServiceTest.java
@@ -28,8 +28,8 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static com.wms.shared.exception.ResourceNotFoundAssertions.assertResourceNotFound;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;

--- a/backend/src/test/java/com/wms/report/service/ShippingInspectionReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/ShippingInspectionReportServiceTest.java
@@ -25,8 +25,8 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static com.wms.shared.exception.ResourceNotFoundAssertions.assertResourceNotFound;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;

--- a/backend/src/test/java/com/wms/report/service/ShippingInspectionReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/ShippingInspectionReportServiceTest.java
@@ -8,7 +8,6 @@ import com.wms.outbound.entity.OutboundSlip;
 import com.wms.outbound.repository.OutboundSlipRepository;
 import com.wms.report.repository.OutboundReportRepository;
 import com.wms.report.repository.projection.ShippingInspectionRow;
-import com.wms.shared.exception.ResourceNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -27,7 +26,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static com.wms.shared.exception.ResourceNotFoundAssertions.assertResourceNotFound;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
@@ -294,17 +294,12 @@ class ShippingInspectionReportServiceTest {
         void generate_slipNotFound_throwsException() {
             when(outboundSlipRepository.findById(999L)).thenReturn(Optional.empty());
 
-            assertThatThrownBy(() -> service.generate(999L, ReportFormat.JSON))
-                    .isInstanceOf(ResourceNotFoundException.class)
-                    .hasMessageContaining("出荷伝票 が見つかりません")
-                    .hasMessageNotContaining("id=")
-                    .hasMessageNotContaining("999")
-                    .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
-                            .isEqualTo("OUTBOUND_SLIP_NOT_FOUND"));
+            Throwable thrown = catchThrowable(() -> service.generate(999L, ReportFormat.JSON));
+            assertResourceNotFound(thrown, "OUTBOUND_SLIP_NOT_FOUND", "出荷伝票");
         }
 
         @Test
-        @DisplayName("倉庫が存在しない場合はResourceNotFoundException")
+        @DisplayName("倉庫が存在しない場合はResourceNotFoundException (連鎖 lookup: 出荷伝票 1L 成功 → 倉庫 999L 失敗)")
         void generate_warehouseNotFound_throwsException() {
             OutboundSlip slip = OutboundSlip.builder()
                     .id(1L)
@@ -315,13 +310,8 @@ class ShippingInspectionReportServiceTest {
             when(outboundSlipRepository.findById(1L)).thenReturn(Optional.of(slip));
             when(warehouseRepository.findById(999L)).thenReturn(Optional.empty());
 
-            assertThatThrownBy(() -> service.generate(1L, ReportFormat.JSON))
-                    .isInstanceOf(ResourceNotFoundException.class)
-                    .hasMessageContaining("倉庫 が見つかりません")
-                    .hasMessageNotContaining("id=")
-                    .hasMessageNotContaining("999")
-                    .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
-                            .isEqualTo("WAREHOUSE_NOT_FOUND"));
+            Throwable thrown = catchThrowable(() -> service.generate(1L, ReportFormat.JSON));
+            assertResourceNotFound(thrown, "WAREHOUSE_NOT_FOUND", "倉庫");
         }
     }
 }

--- a/backend/src/test/java/com/wms/report/service/ShippingInspectionReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/ShippingInspectionReportServiceTest.java
@@ -296,6 +296,9 @@ class ShippingInspectionReportServiceTest {
 
             assertThatThrownBy(() -> service.generate(999L, ReportFormat.JSON))
                     .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageContaining("出荷伝票 が見つかりません")
+                    .hasMessageNotContaining("id=")
+                    .hasMessageNotContaining("999")
                     .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
                             .isEqualTo("OUTBOUND_SLIP_NOT_FOUND"));
         }
@@ -314,6 +317,9 @@ class ShippingInspectionReportServiceTest {
 
             assertThatThrownBy(() -> service.generate(1L, ReportFormat.JSON))
                     .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageContaining("倉庫 が見つかりません")
+                    .hasMessageNotContaining("id=")
+                    .hasMessageNotContaining("999")
                     .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
                             .isEqualTo("WAREHOUSE_NOT_FOUND"));
         }

--- a/backend/src/test/java/com/wms/report/service/StocktakeListReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/StocktakeListReportServiceTest.java
@@ -11,7 +11,6 @@ import com.wms.master.repository.WarehouseRepository;
 import com.wms.report.repository.StocktakeReportRepository;
 import com.wms.report.repository.projection.StocktakeListRow;
 import com.wms.shared.exception.BusinessRuleViolationException;
-import com.wms.shared.exception.ResourceNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -29,8 +28,10 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
+import static com.wms.shared.exception.ResourceNotFoundAssertions.assertResourceNotFound;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
@@ -288,13 +289,9 @@ class StocktakeListReportServiceTest {
         void generate_stocktakeNotFound_throwsException() {
             when(stocktakeHeaderRepository.findById(999L)).thenReturn(Optional.empty());
 
-            assertThatThrownBy(() -> service.generate(999L, null, null, null, ReportFormat.JSON))
-                    .isInstanceOf(ResourceNotFoundException.class)
-                    .hasMessageContaining("棚卸 が見つかりません")
-                    .hasMessageNotContaining("id=")
-                    .hasMessageNotContaining("999")
-                    .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
-                            .isEqualTo("STOCKTAKE_NOT_FOUND"));
+            Throwable stocktakeThrown = catchThrowable(
+                    () -> service.generate(999L, null, null, null, ReportFormat.JSON));
+            assertResourceNotFound(stocktakeThrown, "STOCKTAKE_NOT_FOUND", "棚卸");
         }
 
         @Test
@@ -302,45 +299,33 @@ class StocktakeListReportServiceTest {
         void generate_buildingNotFound_throwsException() {
             when(buildingRepository.findById(999L)).thenReturn(Optional.empty());
 
-            assertThatThrownBy(() -> service.generate(null, 999L, null, null, ReportFormat.JSON))
-                    .isInstanceOf(ResourceNotFoundException.class)
-                    .hasMessageContaining("棟 が見つかりません")
-                    .hasMessageNotContaining("id=")
-                    .hasMessageNotContaining("999")
-                    .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
-                            .isEqualTo("BUILDING_NOT_FOUND"));
+            Throwable thrown = catchThrowable(
+                    () -> service.generate(null, 999L, null, null, ReportFormat.JSON));
+            assertResourceNotFound(thrown, "BUILDING_NOT_FOUND", "棟");
         }
 
         @Test
-        @DisplayName("棚卸の倉庫が存在しない場合はResourceNotFoundException")
+        @DisplayName("棚卸の倉庫が存在しない場合はResourceNotFoundException (連鎖 lookup: 棚卸 10L 成功 → 倉庫 999L 失敗)")
         void generate_stocktakeWarehouseNotFound_throwsException() {
             stocktakeHeader.setWarehouseId(999L);
             when(stocktakeHeaderRepository.findById(10L)).thenReturn(Optional.of(stocktakeHeader));
             when(warehouseRepository.findById(999L)).thenReturn(Optional.empty());
 
-            assertThatThrownBy(() -> service.generate(10L, null, null, null, ReportFormat.JSON))
-                    .isInstanceOf(ResourceNotFoundException.class)
-                    .hasMessageContaining("倉庫 が見つかりません")
-                    .hasMessageNotContaining("id=")
-                    .hasMessageNotContaining("999")
-                    .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
-                            .isEqualTo("WAREHOUSE_NOT_FOUND"));
+            Throwable thrown = catchThrowable(
+                    () -> service.generate(10L, null, null, null, ReportFormat.JSON));
+            assertResourceNotFound(thrown, "WAREHOUSE_NOT_FOUND", "倉庫");
         }
 
         @Test
-        @DisplayName("棟の倉庫が存在しない場合はResourceNotFoundException")
+        @DisplayName("棟の倉庫が存在しない場合はResourceNotFoundException (連鎖 lookup: 棟 5L 成功 → 倉庫 999L 失敗)")
         void generate_buildingWarehouseNotFound_throwsException() {
             building.setWarehouseId(999L);
             when(buildingRepository.findById(5L)).thenReturn(Optional.of(building));
             when(warehouseRepository.findById(999L)).thenReturn(Optional.empty());
 
-            assertThatThrownBy(() -> service.generate(null, 5L, null, null, ReportFormat.JSON))
-                    .isInstanceOf(ResourceNotFoundException.class)
-                    .hasMessageContaining("倉庫 が見つかりません")
-                    .hasMessageNotContaining("id=")
-                    .hasMessageNotContaining("999")
-                    .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
-                            .isEqualTo("WAREHOUSE_NOT_FOUND"));
+            Throwable thrown = catchThrowable(
+                    () -> service.generate(null, 5L, null, null, ReportFormat.JSON));
+            assertResourceNotFound(thrown, "WAREHOUSE_NOT_FOUND", "倉庫");
         }
     }
 

--- a/backend/src/test/java/com/wms/report/service/StocktakeListReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/StocktakeListReportServiceTest.java
@@ -290,6 +290,9 @@ class StocktakeListReportServiceTest {
 
             assertThatThrownBy(() -> service.generate(999L, null, null, null, ReportFormat.JSON))
                     .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageContaining("棚卸 が見つかりません")
+                    .hasMessageNotContaining("id=")
+                    .hasMessageNotContaining("999")
                     .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
                             .isEqualTo("STOCKTAKE_NOT_FOUND"));
         }
@@ -301,6 +304,9 @@ class StocktakeListReportServiceTest {
 
             assertThatThrownBy(() -> service.generate(null, 999L, null, null, ReportFormat.JSON))
                     .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageContaining("棟 が見つかりません")
+                    .hasMessageNotContaining("id=")
+                    .hasMessageNotContaining("999")
                     .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
                             .isEqualTo("BUILDING_NOT_FOUND"));
         }
@@ -314,6 +320,9 @@ class StocktakeListReportServiceTest {
 
             assertThatThrownBy(() -> service.generate(10L, null, null, null, ReportFormat.JSON))
                     .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageContaining("倉庫 が見つかりません")
+                    .hasMessageNotContaining("id=")
+                    .hasMessageNotContaining("999")
                     .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
                             .isEqualTo("WAREHOUSE_NOT_FOUND"));
         }
@@ -327,6 +336,9 @@ class StocktakeListReportServiceTest {
 
             assertThatThrownBy(() -> service.generate(null, 5L, null, null, ReportFormat.JSON))
                     .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageContaining("倉庫 が見つかりません")
+                    .hasMessageNotContaining("id=")
+                    .hasMessageNotContaining("999")
                     .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
                             .isEqualTo("WAREHOUSE_NOT_FOUND"));
         }

--- a/backend/src/test/java/com/wms/report/service/StocktakeResultReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/StocktakeResultReportServiceTest.java
@@ -27,8 +27,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static com.wms.shared.exception.ResourceNotFoundAssertions.assertResourceNotFound;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;

--- a/backend/src/test/java/com/wms/report/service/StocktakeResultReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/StocktakeResultReportServiceTest.java
@@ -8,7 +8,6 @@ import com.wms.master.entity.Warehouse;
 import com.wms.master.repository.WarehouseRepository;
 import com.wms.report.repository.StocktakeReportRepository;
 import com.wms.report.repository.projection.StocktakeResultRow;
-import com.wms.shared.exception.ResourceNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -29,7 +28,8 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static com.wms.shared.exception.ResourceNotFoundAssertions.assertResourceNotFound;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
@@ -384,29 +384,19 @@ class StocktakeResultReportServiceTest {
         void generate_stocktakeNotFound_throwsException() {
             when(stocktakeHeaderRepository.findById(999L)).thenReturn(Optional.empty());
 
-            assertThatThrownBy(() -> service.generate(999L, ReportFormat.JSON))
-                    .isInstanceOf(ResourceNotFoundException.class)
-                    .hasMessageContaining("棚卸 が見つかりません")
-                    .hasMessageNotContaining("id=")
-                    .hasMessageNotContaining("999")
-                    .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
-                            .isEqualTo("STOCKTAKE_NOT_FOUND"));
+            Throwable stocktakeThrown = catchThrowable(() -> service.generate(999L, ReportFormat.JSON));
+            assertResourceNotFound(stocktakeThrown, "STOCKTAKE_NOT_FOUND", "棚卸");
         }
 
         @Test
-        @DisplayName("倉庫が存在しない場合はResourceNotFoundException")
+        @DisplayName("倉庫が存在しない場合はResourceNotFoundException (連鎖 lookup: 棚卸 10L 成功 → 倉庫 999L 失敗)")
         void generate_warehouseNotFound_throwsException() {
             stocktakeHeader.setWarehouseId(999L);
             when(stocktakeHeaderRepository.findById(10L)).thenReturn(Optional.of(stocktakeHeader));
             when(warehouseRepository.findById(999L)).thenReturn(Optional.empty());
 
-            assertThatThrownBy(() -> service.generate(10L, ReportFormat.JSON))
-                    .isInstanceOf(ResourceNotFoundException.class)
-                    .hasMessageContaining("倉庫 が見つかりません")
-                    .hasMessageNotContaining("id=")
-                    .hasMessageNotContaining("999")
-                    .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
-                            .isEqualTo("WAREHOUSE_NOT_FOUND"));
+            Throwable thrown = catchThrowable(() -> service.generate(10L, ReportFormat.JSON));
+            assertResourceNotFound(thrown, "WAREHOUSE_NOT_FOUND", "倉庫");
         }
     }
 

--- a/backend/src/test/java/com/wms/report/service/StocktakeResultReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/StocktakeResultReportServiceTest.java
@@ -386,6 +386,9 @@ class StocktakeResultReportServiceTest {
 
             assertThatThrownBy(() -> service.generate(999L, ReportFormat.JSON))
                     .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageContaining("棚卸 が見つかりません")
+                    .hasMessageNotContaining("id=")
+                    .hasMessageNotContaining("999")
                     .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
                             .isEqualTo("STOCKTAKE_NOT_FOUND"));
         }
@@ -399,6 +402,9 @@ class StocktakeResultReportServiceTest {
 
             assertThatThrownBy(() -> service.generate(10L, ReportFormat.JSON))
                     .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageContaining("倉庫 が見つかりません")
+                    .hasMessageNotContaining("id=")
+                    .hasMessageNotContaining("999")
                     .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
                             .isEqualTo("WAREHOUSE_NOT_FOUND"));
         }

--- a/backend/src/test/java/com/wms/report/service/UnreceivedConfirmedReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/UnreceivedConfirmedReportServiceTest.java
@@ -201,6 +201,9 @@ class UnreceivedConfirmedReportServiceTest {
 
             assertThatThrownBy(() -> service.generate(999L, LocalDate.of(2026, 3, 14), ReportFormat.JSON))
                     .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageContaining("倉庫 が見つかりません")
+                    .hasMessageNotContaining("id=")
+                    .hasMessageNotContaining("999")
                     .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
                             .isEqualTo("WAREHOUSE_NOT_FOUND"));
         }

--- a/backend/src/test/java/com/wms/report/service/UnreceivedConfirmedReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/UnreceivedConfirmedReportServiceTest.java
@@ -24,8 +24,8 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static com.wms.shared.exception.ResourceNotFoundAssertions.assertResourceNotFound;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;

--- a/backend/src/test/java/com/wms/report/service/UnreceivedConfirmedReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/UnreceivedConfirmedReportServiceTest.java
@@ -6,7 +6,6 @@ import com.wms.master.entity.Warehouse;
 import com.wms.master.repository.WarehouseRepository;
 import com.wms.report.entity.UnreceivedListRecord;
 import com.wms.report.repository.UnreceivedListRecordRepository;
-import com.wms.shared.exception.ResourceNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -26,7 +25,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static com.wms.shared.exception.ResourceNotFoundAssertions.assertResourceNotFound;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
@@ -199,13 +199,9 @@ class UnreceivedConfirmedReportServiceTest {
         void generate_warehouseNotFound_throwsException() {
             when(warehouseRepository.findById(999L)).thenReturn(Optional.empty());
 
-            assertThatThrownBy(() -> service.generate(999L, LocalDate.of(2026, 3, 14), ReportFormat.JSON))
-                    .isInstanceOf(ResourceNotFoundException.class)
-                    .hasMessageContaining("倉庫 が見つかりません")
-                    .hasMessageNotContaining("id=")
-                    .hasMessageNotContaining("999")
-                    .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
-                            .isEqualTo("WAREHOUSE_NOT_FOUND"));
+            Throwable thrown = catchThrowable(
+                    () -> service.generate(999L, LocalDate.of(2026, 3, 14), ReportFormat.JSON));
+            assertResourceNotFound(thrown, "WAREHOUSE_NOT_FOUND", "倉庫");
         }
     }
 }

--- a/backend/src/test/java/com/wms/report/service/UnreceivedRealtimeReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/UnreceivedRealtimeReportServiceTest.java
@@ -27,8 +27,8 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static com.wms.shared.exception.ResourceNotFoundAssertions.assertResourceNotFound;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;

--- a/backend/src/test/java/com/wms/report/service/UnreceivedRealtimeReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/UnreceivedRealtimeReportServiceTest.java
@@ -308,6 +308,9 @@ class UnreceivedRealtimeReportServiceTest {
 
             assertThatThrownBy(() -> service.generate(999L, null, ReportFormat.JSON))
                     .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageContaining("倉庫 が見つかりません")
+                    .hasMessageNotContaining("id=")
+                    .hasMessageNotContaining("999")
                     .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
                             .isEqualTo("WAREHOUSE_NOT_FOUND"));
         }

--- a/backend/src/test/java/com/wms/report/service/UnreceivedRealtimeReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/UnreceivedRealtimeReportServiceTest.java
@@ -9,7 +9,6 @@ import com.wms.master.entity.Warehouse;
 import com.wms.master.repository.ProductRepository;
 import com.wms.master.repository.WarehouseRepository;
 import com.wms.report.repository.InboundReportRepository;
-import com.wms.shared.exception.ResourceNotFoundException;
 import com.wms.shared.util.BusinessDateProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -29,7 +28,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static com.wms.shared.exception.ResourceNotFoundAssertions.assertResourceNotFound;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
@@ -306,13 +306,8 @@ class UnreceivedRealtimeReportServiceTest {
         void generate_warehouseNotFound_throwsException() {
             when(warehouseRepository.findById(999L)).thenReturn(Optional.empty());
 
-            assertThatThrownBy(() -> service.generate(999L, null, ReportFormat.JSON))
-                    .isInstanceOf(ResourceNotFoundException.class)
-                    .hasMessageContaining("倉庫 が見つかりません")
-                    .hasMessageNotContaining("id=")
-                    .hasMessageNotContaining("999")
-                    .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
-                            .isEqualTo("WAREHOUSE_NOT_FOUND"));
+            Throwable thrown = catchThrowable(() -> service.generate(999L, null, ReportFormat.JSON));
+            assertResourceNotFound(thrown, "WAREHOUSE_NOT_FOUND", "倉庫");
         }
     }
 }

--- a/backend/src/test/java/com/wms/report/service/UnshippedConfirmedReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/UnshippedConfirmedReportServiceTest.java
@@ -6,7 +6,6 @@ import com.wms.master.entity.Warehouse;
 import com.wms.master.repository.WarehouseRepository;
 import com.wms.report.entity.UnshippedListRecord;
 import com.wms.report.repository.UnshippedListRecordRepository;
-import com.wms.shared.exception.ResourceNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -26,7 +25,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static com.wms.shared.exception.ResourceNotFoundAssertions.assertResourceNotFound;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.verify;
@@ -303,13 +303,9 @@ class UnshippedConfirmedReportServiceTest {
         void generate_warehouseNotFound_throwsException() {
             when(warehouseRepository.findById(999L)).thenReturn(Optional.empty());
 
-            assertThatThrownBy(() -> service.generate(999L, LocalDate.of(2026, 3, 14), ReportFormat.JSON))
-                    .isInstanceOf(ResourceNotFoundException.class)
-                    .hasMessageContaining("倉庫 が見つかりません")
-                    .hasMessageNotContaining("id=")
-                    .hasMessageNotContaining("999")
-                    .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
-                            .isEqualTo("WAREHOUSE_NOT_FOUND"));
+            Throwable thrown = catchThrowable(
+                    () -> service.generate(999L, LocalDate.of(2026, 3, 14), ReportFormat.JSON));
+            assertResourceNotFound(thrown, "WAREHOUSE_NOT_FOUND", "倉庫");
         }
     }
 }

--- a/backend/src/test/java/com/wms/report/service/UnshippedConfirmedReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/UnshippedConfirmedReportServiceTest.java
@@ -305,6 +305,9 @@ class UnshippedConfirmedReportServiceTest {
 
             assertThatThrownBy(() -> service.generate(999L, LocalDate.of(2026, 3, 14), ReportFormat.JSON))
                     .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageContaining("倉庫 が見つかりません")
+                    .hasMessageNotContaining("id=")
+                    .hasMessageNotContaining("999")
                     .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
                             .isEqualTo("WAREHOUSE_NOT_FOUND"));
         }

--- a/backend/src/test/java/com/wms/report/service/UnshippedConfirmedReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/UnshippedConfirmedReportServiceTest.java
@@ -24,8 +24,8 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static com.wms.shared.exception.ResourceNotFoundAssertions.assertResourceNotFound;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;

--- a/backend/src/test/java/com/wms/report/service/UnshippedRealtimeReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/UnshippedRealtimeReportServiceTest.java
@@ -24,8 +24,8 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static com.wms.shared.exception.ResourceNotFoundAssertions.assertResourceNotFound;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;

--- a/backend/src/test/java/com/wms/report/service/UnshippedRealtimeReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/UnshippedRealtimeReportServiceTest.java
@@ -6,7 +6,6 @@ import com.wms.master.entity.Warehouse;
 import com.wms.master.repository.WarehouseRepository;
 import com.wms.report.repository.OutboundReportRepository;
 import com.wms.report.repository.projection.UnshippedRealtimeRow;
-import com.wms.shared.exception.ResourceNotFoundException;
 import com.wms.shared.util.BusinessDateProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -26,7 +25,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static com.wms.shared.exception.ResourceNotFoundAssertions.assertResourceNotFound;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
@@ -325,13 +325,8 @@ class UnshippedRealtimeReportServiceTest {
         void generate_warehouseNotFound_throwsException() {
             when(warehouseRepository.findById(999L)).thenReturn(Optional.empty());
 
-            assertThatThrownBy(() -> service.generate(999L, null, ReportFormat.JSON))
-                    .isInstanceOf(ResourceNotFoundException.class)
-                    .hasMessageContaining("倉庫 が見つかりません")
-                    .hasMessageNotContaining("id=")
-                    .hasMessageNotContaining("999")
-                    .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
-                            .isEqualTo("WAREHOUSE_NOT_FOUND"));
+            Throwable thrown = catchThrowable(() -> service.generate(999L, null, ReportFormat.JSON));
+            assertResourceNotFound(thrown, "WAREHOUSE_NOT_FOUND", "倉庫");
         }
     }
 }

--- a/backend/src/test/java/com/wms/report/service/UnshippedRealtimeReportServiceTest.java
+++ b/backend/src/test/java/com/wms/report/service/UnshippedRealtimeReportServiceTest.java
@@ -327,6 +327,9 @@ class UnshippedRealtimeReportServiceTest {
 
             assertThatThrownBy(() -> service.generate(999L, null, ReportFormat.JSON))
                     .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageContaining("倉庫 が見つかりません")
+                    .hasMessageNotContaining("id=")
+                    .hasMessageNotContaining("999")
                     .satisfies(ex -> assertThat(((ResourceNotFoundException) ex).getErrorCode())
                             .isEqualTo("WAREHOUSE_NOT_FOUND"));
         }

--- a/backend/src/test/java/com/wms/shared/exception/ExceptionClassesTest.java
+++ b/backend/src/test/java/com/wms/shared/exception/ExceptionClassesTest.java
@@ -1,8 +1,15 @@
 package com.wms.shared.exception;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -69,6 +76,53 @@ class ExceptionClassesTest {
             assertThat(ex.getMessage()).isEqualTo("ユーザー が見つかりません");
             assertThat(ex.getMessage()).doesNotContain("admin");
             assertThat(ex.getMessage()).doesNotContain("id=");
+        }
+
+        @Nested
+        @DisplayName("of() 副作用ログ検証 (仕様: ファクトリ内部で log.info を出力)")
+        class OfSideEffectLogTest {
+
+            private Logger factoryLogger;
+            private ListAppender<ILoggingEvent> appender;
+
+            @BeforeEach
+            void setUp() {
+                factoryLogger = (Logger) LoggerFactory.getLogger(ResourceNotFoundException.class);
+                appender = new ListAppender<>();
+                appender.start();
+                factoryLogger.addAppender(appender);
+            }
+
+            @AfterEach
+            void tearDown() {
+                factoryLogger.detachAppender(appender);
+                appender.stop();
+            }
+
+            @Test
+            @DisplayName("of(): INFO レベルで 'resourceName not found: id=<id>, errorCode=<code>' が出力される")
+            void of_emitsInfoLogWithIdAndErrorCode() {
+                ResourceNotFoundException.of("WAREHOUSE_NOT_FOUND", "倉庫", 42L);
+
+                assertThat(appender.list)
+                        .as("ファクトリ呼び出しで 1 件の INFO ログが出力される")
+                        .hasSize(1);
+                ILoggingEvent event = appender.list.get(0);
+                assertThat(event.getLevel()).isEqualTo(Level.INFO);
+                // SLF4J のパラメータ付きメッセージはフォーマット済み文字列を getFormattedMessage() で取得
+                assertThat(event.getFormattedMessage())
+                        .isEqualTo("倉庫 not found: id=42, errorCode=WAREHOUSE_NOT_FOUND");
+            }
+
+            @Test
+            @DisplayName("of(): 文字列IDでもログには id が出力される (メッセージには埋め込まれない)")
+            void of_withStringId_emitsInfoLogWithStringId() {
+                ResourceNotFoundException.of("USER_NOT_FOUND", "ユーザー", "admin");
+
+                assertThat(appender.list).hasSize(1);
+                assertThat(appender.list.get(0).getFormattedMessage())
+                        .isEqualTo("ユーザー not found: id=admin, errorCode=USER_NOT_FOUND");
+            }
         }
     }
 

--- a/backend/src/test/java/com/wms/shared/exception/ResourceNotFoundAssertions.java
+++ b/backend/src/test/java/com/wms/shared/exception/ResourceNotFoundAssertions.java
@@ -1,0 +1,51 @@
+package com.wms.shared.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@link ResourceNotFoundException} 用テストアサーションヘルパ。
+ *
+ * <p><strong>目的:</strong> OWASP A09 (Security Logging and Monitoring Failures) 対応の検証として、
+ * 例外メッセージが {@link ResourceNotFoundException#of(String, String, Object)} ファクトリが生成する
+ * 固定文言 ({@code "<resourceName> が見つかりません"}) と <strong>完全一致</strong> することを保証する。
+ *
+ * <p>完全一致アサーションにより、以下をワンショットで担保できる:
+ * <ul>
+ *   <li>内部 PK (id) 値がメッセージに混入していない — 連鎖 lookup (先行 entity → 後続 entity) ケースで
+ *       先行 lookup の id (例: {@code 1L}, {@code 5L}, {@code 10L} 等) が漏れていても検知可能。
+ *       {@code hasMessageNotContaining("999")} のような特定値ホワイトリスト方式の盲点を排除する。</li>
+ *   <li>{@code "id="} 等の構造的リーク文字列が含まれない — 単なる文字列非包含アサーションのトートロジー
+ *       (ファクトリ仕様上そもそも {@code id=} は出力されないため常に真) を排除する。</li>
+ *   <li>追加情報 (stack trace 以外の付帯文字列) が一切混入していない。</li>
+ * </ul>
+ *
+ * <p>本ヘルパはファクトリ実装 ({@link ResourceNotFoundException#of(String, String, Object)}) の
+ * フォーマット文字列 {@code "%s が見つかりません"} (半角スペース 1 つ) にロックオンしている。
+ * ファクトリ実装のフォーマットを変更する場合は、本ヘルパも合わせて更新すること。
+ */
+public final class ResourceNotFoundAssertions {
+
+    private ResourceNotFoundAssertions() {
+        // utility class
+    }
+
+    /**
+     * throwable が {@link ResourceNotFoundException} であり、errorCode が一致し、メッセージが
+     * {@code "<resourceName> が見つかりません"} と完全一致することを検証する。
+     *
+     * @param thrown       検査対象 throwable (通常 {@code catchThrowable(...)} の戻り値)
+     * @param errorCode    期待する errorCode (例: {@code "WAREHOUSE_NOT_FOUND"})
+     * @param resourceName 期待する resourceName (例: {@code "倉庫"}, {@code "棚卸"})
+     */
+    public static void assertResourceNotFound(Throwable thrown,
+                                              String errorCode,
+                                              String resourceName) {
+        assertThat(thrown)
+                .as("ResourceNotFoundException であること")
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage(String.format("%s が見つかりません", resourceName));
+        assertThat(((ResourceNotFoundException) thrown).getErrorCode())
+                .as("errorCode が一致すること")
+                .isEqualTo(errorCode);
+    }
+}


### PR DESCRIPTION
Closes #472

## Summary
- report モジュール全16サービスの `ResourceNotFoundException` メッセージから内部 PK（warehouseId / slipId / productId / buildingId / stocktakeId / pickingInstructionId）を除去
- `ResourceNotFoundException.of(code, name, id)` ファクトリに統一し、id はサーバーログのみに出力
- テストアサーションを共通ヘルパー `assertResourceNotFound()` に統一（`hasMessage()` 完全一致）
- `ResourceNotFoundException.of()` に CRLF ログインジェクション注意の Javadoc 追加
- テストファイルの import 順序修正

## Test coverage
### Backend (JaCoCo)
| 指標 | 値 |
|------|-----|
| C0（LINE） | 100% |
| C1（BRANCH） | 100% |

※ report モジュール + shared/exception のみ。BatchExecutionLog（スコープ外）は除外。

## Test plan
- [x] report モジュール全12テストクラスの全テストがグリーン
- [x] shared/exception テストがグリーン
- [x] 全テストで `assertResourceNotFound` ヘルパーによる完全一致検証
- [x] `./gradlew :backend:test jacocoTestReport` で C0/C1 100% 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)