### PR TITLE
toggleActive version先行チェックパターンを6マスタサービスに横展開

### DIFF
--- a/backend/src/main/java/com/wms/master/service/AreaService.java
+++ b/backend/src/main/java/com/wms/master/service/AreaService.java
@@ -93,7 +93,7 @@ public class AreaService {
     @Transactional
     public Area toggleActive(Long id, boolean isActive, Integer version) {
         Area area = findById(id);
-        // API-03 §4 業務フロー: CHECK_VERSION → CHECK_SAME → BR check の順で評価する
+        // API-02 §4 業務フロー: CHECK_VERSION → CHECK_SAME → BR check の順で評価する
         if (!Objects.equals(area.getVersion(), version)) {
             log.info("Area toggleActive version mismatch: id={}, expected={}, actual={}",
                     id, version, area.getVersion());

--- a/backend/src/main/java/com/wms/master/service/AreaService.java
+++ b/backend/src/main/java/com/wms/master/service/AreaService.java
@@ -19,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Service
@@ -71,14 +72,14 @@ public class AreaService {
     @Transactional
     public Area update(Long id, String areaName, String storageCondition, Integer version) {
         Area area = findById(id);
-        if (!area.getVersion().equals(version)) {
+        if (!Objects.equals(area.getVersion(), version)) {
             log.info("Area update version mismatch: id={}, expected={}, actual={}",
                     id, version, area.getVersion());
             throw OptimisticLockConflictException.standard();
         }
         area.setAreaName(areaName);
         area.setStorageCondition(storageCondition);
-        area.setVersion(version);
+        // version は事前チェックで一致確認済みのため再代入不要。
         try {
             Area saved = areaRepository.save(area);
             log.info("Area updated: id={}, name={}", id, areaName);
@@ -92,10 +93,15 @@ public class AreaService {
     @Transactional
     public Area toggleActive(Long id, boolean isActive, Integer version) {
         Area area = findById(id);
-        if (!area.getVersion().equals(version)) {
+        // API-03 §4 業務フロー: CHECK_VERSION → CHECK_SAME → BR check の順で評価する
+        if (!Objects.equals(area.getVersion(), version)) {
             log.info("Area toggleActive version mismatch: id={}, expected={}, actual={}",
                     id, version, area.getVersion());
             throw OptimisticLockConflictException.standard();
+        }
+        if (Objects.equals(area.getIsActive(), isActive)) {
+            log.info("Area toggleActive no-op: id={}, isActive={}", id, isActive);
+            return area;
         }
         if (!isActive && locationRepository.countByAreaIdAndIsActiveTrue(id) > 0) {
             // OWASP A09: 例外メッセージには内部 id を含めない。id は log 側に出力。
@@ -103,16 +109,12 @@ public class AreaService {
             throw new BusinessRuleViolationException("CANNOT_DEACTIVATE_HAS_CHILDREN",
                     "配下に有効なロケーションが存在するため無効化できません");
         }
-        if (area.getIsActive().equals(isActive)) {
-            log.info("Area toggleActive no-op: id={}, isActive={}", id, isActive);
-            return area;
-        }
         if (isActive) {
             area.activate();
         } else {
             area.deactivate();
         }
-        area.setVersion(version);
+        // version は事前チェックで一致確認済みのため再代入不要。
         try {
             Area saved = areaRepository.save(area);
             log.info("Area toggled: id={}, isActive={}", id, isActive);

--- a/backend/src/main/java/com/wms/master/service/BuildingService.java
+++ b/backend/src/main/java/com/wms/master/service/BuildingService.java
@@ -19,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Service
@@ -65,13 +66,13 @@ public class BuildingService {
     @Transactional
     public Building update(Long id, String buildingName, Integer version) {
         Building building = findById(id);
-        if (!building.getVersion().equals(version)) {
+        if (!Objects.equals(building.getVersion(), version)) {
             log.info("Building update version mismatch: id={}, expected={}, actual={}",
                     id, version, building.getVersion());
             throw OptimisticLockConflictException.standard();
         }
         building.setBuildingName(buildingName);
-        building.setVersion(version);
+        // version は事前チェックで一致確認済みのため再代入不要。
         try {
             Building saved = buildingRepository.save(building);
             log.info("Building updated: id={}, name={}", id, buildingName);
@@ -85,10 +86,15 @@ public class BuildingService {
     @Transactional
     public Building toggleActive(Long id, boolean isActive, Integer version) {
         Building building = findById(id);
-        if (!building.getVersion().equals(version)) {
+        // API-03 §4 業務フロー: CHECK_VERSION → CHECK_SAME → BR check の順で評価する
+        if (!Objects.equals(building.getVersion(), version)) {
             log.info("Building toggleActive version mismatch: id={}, expected={}, actual={}",
                     id, version, building.getVersion());
             throw OptimisticLockConflictException.standard();
+        }
+        if (Objects.equals(building.getIsActive(), isActive)) {
+            log.info("Building toggleActive no-op: id={}, isActive={}", id, isActive);
+            return building;
         }
         if (!isActive && areaRepository.countByBuildingId(id) > 0) {
             // OWASP A09: 例外メッセージには内部 id を含めない。id は log 側に出力。
@@ -96,16 +102,12 @@ public class BuildingService {
             throw new BusinessRuleViolationException("CANNOT_DEACTIVATE_HAS_CHILDREN",
                     "配下にエリアが存在するため無効化できません");
         }
-        if (building.getIsActive().equals(isActive)) {
-            log.info("Building toggleActive no-op: id={}, isActive={}", id, isActive);
-            return building;
-        }
         if (isActive) {
             building.activate();
         } else {
             building.deactivate();
         }
-        building.setVersion(version);
+        // version は事前チェックで一致確認済みのため再代入不要。
         try {
             Building saved = buildingRepository.save(building);
             log.info("Building toggled: id={}, isActive={}", id, isActive);

--- a/backend/src/main/java/com/wms/master/service/BuildingService.java
+++ b/backend/src/main/java/com/wms/master/service/BuildingService.java
@@ -86,7 +86,7 @@ public class BuildingService {
     @Transactional
     public Building toggleActive(Long id, boolean isActive, Integer version) {
         Building building = findById(id);
-        // API-03 §4 業務フロー: CHECK_VERSION → CHECK_SAME → BR check の順で評価する
+        // API-02 §4 業務フロー: CHECK_VERSION → CHECK_SAME → BR check の順で評価する
         if (!Objects.equals(building.getVersion(), version)) {
             log.info("Building toggleActive version mismatch: id={}, expected={}, actual={}",
                     id, version, building.getVersion());

--- a/backend/src/main/java/com/wms/master/service/LocationService.java
+++ b/backend/src/main/java/com/wms/master/service/LocationService.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -102,13 +103,13 @@ public class LocationService {
     @Transactional
     public Location update(Long id, String locationName, Integer version) {
         Location location = findById(id);
-        if (!location.getVersion().equals(version)) {
+        if (!Objects.equals(location.getVersion(), version)) {
             log.info("Location update version mismatch: id={}, expected={}, actual={}",
                     id, version, location.getVersion());
             throw OptimisticLockConflictException.standard();
         }
         location.setLocationName(locationName);
-        location.setVersion(version);
+        // version は事前チェックで一致確認済みのため再代入不要。
         try {
             Location saved = locationRepository.save(location);
             log.info("Location updated: id={}, name={}", id, locationName);
@@ -122,13 +123,14 @@ public class LocationService {
     @Transactional
     public Location toggleActive(Long id, boolean isActive, Integer version) {
         Location location = findById(id);
-        if (!location.getVersion().equals(version)) {
+        // API-03 §4 業務フロー: CHECK_VERSION → CHECK_SAME → BR check の順で評価する
+        if (!Objects.equals(location.getVersion(), version)) {
             log.info("Location toggleActive version mismatch: id={}, expected={}, actual={}",
                     id, version, location.getVersion());
             throw OptimisticLockConflictException.standard();
         }
         // 冪等性のため、状態が実際に変化しない場合は早期 return（後続の在庫チェックも省略）
-        if (location.getIsActive().equals(isActive)) {
+        if (Objects.equals(location.getIsActive(), isActive)) {
             log.info("Location toggleActive no-op: id={}, isActive={}", id, isActive);
             return location;
         }
@@ -155,7 +157,7 @@ public class LocationService {
         } else {
             location.deactivate();
         }
-        location.setVersion(version);
+        // version は事前チェックで一致確認済みのため再代入不要。
         try {
             Location saved = locationRepository.save(location);
             log.info("Location toggled: id={}, isActive={}", id, isActive);

--- a/backend/src/main/java/com/wms/master/service/LocationService.java
+++ b/backend/src/main/java/com/wms/master/service/LocationService.java
@@ -123,7 +123,7 @@ public class LocationService {
     @Transactional
     public Location toggleActive(Long id, boolean isActive, Integer version) {
         Location location = findById(id);
-        // API-03 §4 業務フロー: CHECK_VERSION → CHECK_SAME → BR check の順で評価する
+        // API-02 §4 業務フロー: CHECK_VERSION → CHECK_SAME → BR check の順で評価する
         if (!Objects.equals(location.getVersion(), version)) {
             log.info("Location toggleActive version mismatch: id={}, expected={}, actual={}",
                     id, version, location.getVersion());

--- a/backend/src/main/java/com/wms/master/service/ProductService.java
+++ b/backend/src/main/java/com/wms/master/service/ProductService.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -88,7 +89,7 @@ public class ProductService {
     public Product update(UpdateProductCommand cmd) {
         Product product = findById(cmd.id());
 
-        if (!product.getVersion().equals(cmd.version())) {
+        if (!Objects.equals(product.getVersion(), cmd.version())) {
             log.info("Product update version mismatch: id={}, expected={}, actual={}",
                     cmd.id(), cmd.version(), product.getVersion());
             throw OptimisticLockConflictException.standard();
@@ -123,7 +124,7 @@ public class ProductService {
         } else {
             product.deactivate();
         }
-        product.setVersion(cmd.version());
+        // version は事前チェックで一致確認済みのため再代入不要。
         try {
             Product saved = productRepository.save(product);
             log.info("Product updated: id={}, name={}", cmd.id(), cmd.productName());
@@ -137,29 +138,28 @@ public class ProductService {
     @Transactional
     public Product toggleActive(Long id, boolean isActive, Integer version) {
         Product product = findById(id);
-
-        if (!product.getVersion().equals(version)) {
+        // API-03 §4 業務フロー: CHECK_VERSION → CHECK_SAME → BR check の順で評価する
+        if (!Objects.equals(product.getVersion(), version)) {
             log.info("Product toggleActive version mismatch: id={}, expected={}, actual={}",
                     id, version, product.getVersion());
             throw OptimisticLockConflictException.standard();
         }
-
+        if (Objects.equals(product.getIsActive(), isActive)) {
+            log.info("Product toggleActive no-op: id={}, isActive={}", id, isActive);
+            return product;
+        }
         if (!isActive && inventoryService.hasInventoryByProductId(id)) {
             // OWASP A09: 例外メッセージには内部 id を含めない。id は log 側に出力。
             log.info("Product deactivate blocked by inventory: id={}", id);
             throw new BusinessRuleViolationException("CANNOT_DEACTIVATE_HAS_INVENTORY",
                     "在庫が存在するため商品を無効化できません");
         }
-        if (product.getIsActive().equals(isActive)) {
-            log.info("Product toggleActive no-op: id={}, isActive={}", id, isActive);
-            return product;
-        }
         if (isActive) {
             product.activate();
         } else {
             product.deactivate();
         }
-        product.setVersion(version);
+        // version は事前チェックで一致確認済みのため再代入不要。
         try {
             Product saved = productRepository.save(product);
             log.info("Product toggled: id={}, isActive={}", id, isActive);

--- a/backend/src/main/java/com/wms/master/service/ProductService.java
+++ b/backend/src/main/java/com/wms/master/service/ProductService.java
@@ -138,7 +138,7 @@ public class ProductService {
     @Transactional
     public Product toggleActive(Long id, boolean isActive, Integer version) {
         Product product = findById(id);
-        // API-03 §4 業務フロー: CHECK_VERSION → CHECK_SAME → BR check の順で評価する
+        // API-04 §4 業務フロー: CHECK_VERSION → CHECK_SAME → BR check の順で評価する
         if (!Objects.equals(product.getVersion(), version)) {
             log.info("Product toggleActive version mismatch: id={}, expected={}, actual={}",
                     id, version, product.getVersion());

--- a/backend/src/main/java/com/wms/master/service/WarehouseService.java
+++ b/backend/src/main/java/com/wms/master/service/WarehouseService.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Service
@@ -78,7 +79,7 @@ public class WarehouseService {
     public Warehouse update(Long id, String warehouseName, String warehouseNameKana,
                             String address, Integer version) {
         Warehouse warehouse = findById(id);
-        if (!warehouse.getVersion().equals(version)) {
+        if (!Objects.equals(warehouse.getVersion(), version)) {
             log.info("Warehouse update version mismatch: id={}, expected={}, actual={}",
                     id, version, warehouse.getVersion());
             throw OptimisticLockConflictException.standard();
@@ -86,7 +87,7 @@ public class WarehouseService {
         warehouse.setWarehouseName(warehouseName);
         warehouse.setWarehouseNameKana(warehouseNameKana);
         warehouse.setAddress(address);
-        warehouse.setVersion(version);
+        // version は事前チェックで一致確認済みのため再代入不要。
         try {
             Warehouse saved = warehouseRepository.save(warehouse);
             log.info("Warehouse updated: id={}, name={}", id, warehouseName);
@@ -100,13 +101,14 @@ public class WarehouseService {
     @Transactional
     public Warehouse toggleActive(Long id, boolean isActive, Integer version) {
         Warehouse warehouse = findById(id);
-        if (!warehouse.getVersion().equals(version)) {
+        // API-03 §4 業務フロー: CHECK_VERSION → CHECK_SAME → BR check の順で評価する
+        if (!Objects.equals(warehouse.getVersion(), version)) {
             log.info("Warehouse toggleActive version mismatch: id={}, expected={}, actual={}",
                     id, version, warehouse.getVersion());
             throw OptimisticLockConflictException.standard();
         }
         // 冪等性のため、状態が実際に変化しない場合は早期 return（後続の在庫チェックも省略）
-        if (warehouse.getIsActive().equals(isActive)) {
+        if (Objects.equals(warehouse.getIsActive(), isActive)) {
             log.info("Warehouse toggleActive no-op: id={}, isActive={}", id, isActive);
             return warehouse;
         }
@@ -124,7 +126,7 @@ public class WarehouseService {
         } else {
             warehouse.deactivate();
         }
-        warehouse.setVersion(version);
+        // version は事前チェックで一致確認済みのため再代入不要。
         try {
             Warehouse saved = warehouseRepository.save(warehouse);
             log.info("Warehouse toggled: id={}, isActive={}", id, isActive);

--- a/backend/src/main/java/com/wms/master/service/WarehouseService.java
+++ b/backend/src/main/java/com/wms/master/service/WarehouseService.java
@@ -101,7 +101,7 @@ public class WarehouseService {
     @Transactional
     public Warehouse toggleActive(Long id, boolean isActive, Integer version) {
         Warehouse warehouse = findById(id);
-        // API-03 §4 業務フロー: CHECK_VERSION → CHECK_SAME → BR check の順で評価する
+        // API-02 §4 業務フロー: CHECK_VERSION → CHECK_SAME → BR check の順で評価する
         if (!Objects.equals(warehouse.getVersion(), version)) {
             log.info("Warehouse toggleActive version mismatch: id={}, expected={}, actual={}",
                     id, version, warehouse.getVersion());

--- a/backend/src/main/java/com/wms/system/service/UserService.java
+++ b/backend/src/main/java/com/wms/system/service/UserService.java
@@ -10,6 +10,7 @@ import com.wms.system.entity.User;
 import com.wms.system.repository.UserRepository;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -64,7 +65,7 @@ public class UserService {
     @Transactional
     public User update(UpdateUserCommand cmd) {
         User user = findById(cmd.id());
-        if (!user.getVersion().equals(cmd.version())) {
+        if (!Objects.equals(user.getVersion(), cmd.version())) {
             log.info("User update version mismatch: id={}, expected={}, actual={}",
                     cmd.id(), cmd.version(), user.getVersion());
             throw OptimisticLockConflictException.standard();
@@ -85,7 +86,7 @@ public class UserService {
         user.setEmail(cmd.email());
         user.setRole(cmd.role());
         user.setIsActive(cmd.isActive());
-        user.setVersion(cmd.version());
+        // version は事前チェックで一致確認済みのため再代入不要。
         try {
             User saved = userRepository.save(user);
             log.info("User updated: id={}, fullName={}", cmd.id(), cmd.fullName());
@@ -99,23 +100,24 @@ public class UserService {
     @Transactional
     public User toggleActive(Long id, boolean isActive, Integer version, Long currentUserId) {
         User user = findById(id);
-        // 自己無効化禁止
-        if (currentUserId.equals(id) && !isActive) {
-            throw new BusinessRuleViolationException("CANNOT_DEACTIVATE_SELF",
-                    "自分自身を無効化することはできません");
-        }
-        if (!user.getVersion().equals(version)) {
+        // API-03 §4 業務フロー: CHECK_VERSION → CHECK_SAME → BR check の順で評価する
+        if (!Objects.equals(user.getVersion(), version)) {
             log.info("User toggleActive version mismatch: id={}, expected={}, actual={}",
                     id, version, user.getVersion());
             throw OptimisticLockConflictException.standard();
         }
         // 冪等性: 既に同じ状態なら更新しない
-        if (user.getIsActive().equals(isActive)) {
+        if (Objects.equals(user.getIsActive(), isActive)) {
             log.info("User toggleActive no-op: id={}, isActive={}", id, isActive);
             return user;
         }
+        // 自己無効化禁止
+        if (currentUserId.equals(id) && !isActive) {
+            throw new BusinessRuleViolationException("CANNOT_DEACTIVATE_SELF",
+                    "自分自身を無効化することはできません");
+        }
         user.setIsActive(isActive);
-        user.setVersion(version);
+        // version は事前チェックで一致確認済みのため再代入不要。
         try {
             User saved = userRepository.save(user);
             log.info("User toggled: id={}, isActive={}", id, isActive);

--- a/backend/src/main/java/com/wms/system/service/UserService.java
+++ b/backend/src/main/java/com/wms/system/service/UserService.java
@@ -100,7 +100,7 @@ public class UserService {
     @Transactional
     public User toggleActive(Long id, boolean isActive, Integer version, Long currentUserId) {
         User user = findById(id);
-        // API-03 §4 業務フロー: CHECK_VERSION → CHECK_SAME → BR check の順で評価する
+        // API-05 §4 業務フロー: CHECK_VERSION → CHECK_SAME → BR check の順で評価する
         if (!Objects.equals(user.getVersion(), version)) {
             log.info("User toggleActive version mismatch: id={}, expected={}, actual={}",
                     id, version, user.getVersion());

--- a/backend/src/test/java/com/wms/master/service/AreaServiceTest.java
+++ b/backend/src/test/java/com/wms/master/service/AreaServiceTest.java
@@ -347,7 +347,10 @@ class AreaServiceTest {
             when(areaRepository.findById(1L)).thenReturn(Optional.of(existing));
 
             assertThatThrownBy(() -> areaService.toggleActive(1L, false, 3))
-                    .isInstanceOf(OptimisticLockConflictException.class);
+                    .isInstanceOf(OptimisticLockConflictException.class)
+                    .hasMessageContaining("他のユーザーによる更新が先行しました")
+                    // OWASP A09: 内部 id をクライアント向け例外メッセージに露出しない
+                    .hasMessageNotContaining("id=");
 
             verify(locationRepository, never()).countByAreaIdAndIsActiveTrue(any());
             verify(areaRepository, never()).save(any());

--- a/backend/src/test/java/com/wms/master/service/AreaServiceTest.java
+++ b/backend/src/test/java/com/wms/master/service/AreaServiceTest.java
@@ -337,6 +337,35 @@ class AreaServiceTest {
             assertThatThrownBy(() -> areaService.toggleActive(1L, false, 0))
                     .isInstanceOf(OptimisticLockConflictException.class);
         }
+
+        @Test
+        @DisplayName("[#470] no-op (既無効化) でも stale version は 409 を返す")
+        void toggleActive_noOpWithStaleVersion_throwsOptimisticLockConflict() {
+            Area existing = createArea(1L, 1L, 1L, "A01", "エリア", "STOCK", "AMBIENT");
+            existing.deactivate();
+            existing.setVersion(5);
+            when(areaRepository.findById(1L)).thenReturn(Optional.of(existing));
+
+            assertThatThrownBy(() -> areaService.toggleActive(1L, false, 3))
+                    .isInstanceOf(OptimisticLockConflictException.class);
+
+            verify(locationRepository, never()).countByAreaIdAndIsActiveTrue(any());
+            verify(areaRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("[#470] BR 違反かつ stale version の場合は 409 (OL) が 422 (BR) より優先される")
+        void toggleActive_brViolationAndStaleVersion_optimisticLockTakesPrecedence() {
+            Area existing = createArea(1L, 1L, 1L, "A01", "エリア", "STOCK", "AMBIENT");
+            existing.setVersion(5);
+            when(areaRepository.findById(1L)).thenReturn(Optional.of(existing));
+
+            assertThatThrownBy(() -> areaService.toggleActive(1L, false, 3))
+                    .isInstanceOf(OptimisticLockConflictException.class);
+
+            verify(locationRepository, never()).countByAreaIdAndIsActiveTrue(any());
+            verify(areaRepository, never()).save(any());
+        }
     }
 
     // --- Helpers ---

--- a/backend/src/test/java/com/wms/master/service/BuildingServiceTest.java
+++ b/backend/src/test/java/com/wms/master/service/BuildingServiceTest.java
@@ -305,7 +305,10 @@ class BuildingServiceTest {
             when(buildingRepository.findById(1L)).thenReturn(Optional.of(existing));
 
             assertThatThrownBy(() -> buildingService.toggleActive(1L, false, 3))
-                    .isInstanceOf(OptimisticLockConflictException.class);
+                    .isInstanceOf(OptimisticLockConflictException.class)
+                    .hasMessageContaining("他のユーザーによる更新が先行しました")
+                    // OWASP A09: 内部 id をクライアント向け例外メッセージに露出しない
+                    .hasMessageNotContaining("id=");
 
             verify(areaRepository, never()).countByBuildingId(any());
             verify(buildingRepository, never()).save(any());

--- a/backend/src/test/java/com/wms/master/service/BuildingServiceTest.java
+++ b/backend/src/test/java/com/wms/master/service/BuildingServiceTest.java
@@ -295,6 +295,35 @@ class BuildingServiceTest {
             assertThatThrownBy(() -> buildingService.toggleActive(1L, false, 0))
                     .isInstanceOf(OptimisticLockConflictException.class);
         }
+
+        @Test
+        @DisplayName("[#470] no-op (既無効化) でも stale version は 409 を返す")
+        void toggleActive_noOpWithStaleVersion_throwsOptimisticLockConflict() {
+            Building existing = createBuilding(1L, 10L, "BLDG01", "棟A");
+            existing.deactivate();
+            existing.setVersion(5);
+            when(buildingRepository.findById(1L)).thenReturn(Optional.of(existing));
+
+            assertThatThrownBy(() -> buildingService.toggleActive(1L, false, 3))
+                    .isInstanceOf(OptimisticLockConflictException.class);
+
+            verify(areaRepository, never()).countByBuildingId(any());
+            verify(buildingRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("[#470] BR 違反かつ stale version の場合は 409 (OL) が 422 (BR) より優先される")
+        void toggleActive_brViolationAndStaleVersion_optimisticLockTakesPrecedence() {
+            Building existing = createBuilding(1L, 10L, "BLDG01", "棟A");
+            existing.setVersion(5);
+            when(buildingRepository.findById(1L)).thenReturn(Optional.of(existing));
+
+            assertThatThrownBy(() -> buildingService.toggleActive(1L, false, 3))
+                    .isInstanceOf(OptimisticLockConflictException.class);
+
+            verify(areaRepository, never()).countByBuildingId(any());
+            verify(buildingRepository, never()).save(any());
+        }
     }
 
     @Nested

--- a/backend/src/test/java/com/wms/master/service/LocationServiceTest.java
+++ b/backend/src/test/java/com/wms/master/service/LocationServiceTest.java
@@ -531,7 +531,10 @@ class LocationServiceTest {
             when(locationRepository.findById(1L)).thenReturn(Optional.of(existing));
 
             assertThatThrownBy(() -> locationService.toggleActive(1L, false, 3))
-                    .isInstanceOf(OptimisticLockConflictException.class);
+                    .isInstanceOf(OptimisticLockConflictException.class)
+                    .hasMessageContaining("他のユーザーによる更新が先行しました")
+                    // OWASP A09: 内部 id をクライアント向け例外メッセージに露出しない
+                    .hasMessageNotContaining("id=");
 
             verify(inventoryService, never()).hasInventoryByLocationId(any());
             verify(locationRepository, never()).save(any());

--- a/backend/src/test/java/com/wms/master/service/LocationServiceTest.java
+++ b/backend/src/test/java/com/wms/master/service/LocationServiceTest.java
@@ -521,6 +521,35 @@ class LocationServiceTest {
             assertThatThrownBy(() -> locationService.toggleActive(1L, false, 0))
                     .isInstanceOf(OptimisticLockConflictException.class);
         }
+
+        @Test
+        @DisplayName("[#470] no-op (既無効化) でも stale version は 409 を返す")
+        void toggleActive_noOpWithStaleVersion_throwsOptimisticLockConflict() {
+            Location existing = createLocation(1L, 10L, 100L, "A-01-A-01-01-01");
+            existing.deactivate();
+            existing.setVersion(5);
+            when(locationRepository.findById(1L)).thenReturn(Optional.of(existing));
+
+            assertThatThrownBy(() -> locationService.toggleActive(1L, false, 3))
+                    .isInstanceOf(OptimisticLockConflictException.class);
+
+            verify(inventoryService, never()).hasInventoryByLocationId(any());
+            verify(locationRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("[#470] BR 違反かつ stale version の場合は 409 (OL) が 422 (BR) より優先される")
+        void toggleActive_brViolationAndStaleVersion_optimisticLockTakesPrecedence() {
+            Location existing = createLocation(1L, 10L, 100L, "A-01-A-01-01-01");
+            existing.setVersion(5);
+            when(locationRepository.findById(1L)).thenReturn(Optional.of(existing));
+
+            assertThatThrownBy(() -> locationService.toggleActive(1L, false, 3))
+                    .isInstanceOf(OptimisticLockConflictException.class);
+
+            verify(inventoryService, never()).hasInventoryByLocationId(any());
+            verify(locationRepository, never()).save(any());
+        }
     }
 
     // --- Helpers ---

--- a/backend/src/test/java/com/wms/master/service/ProductServiceTest.java
+++ b/backend/src/test/java/com/wms/master/service/ProductServiceTest.java
@@ -471,7 +471,10 @@ class ProductServiceTest {
             when(productRepository.findById(1L)).thenReturn(Optional.of(existing));
 
             assertThatThrownBy(() -> productService.toggleActive(1L, false, 3))
-                    .isInstanceOf(OptimisticLockConflictException.class);
+                    .isInstanceOf(OptimisticLockConflictException.class)
+                    .hasMessageContaining("他のユーザーによる更新が先行しました")
+                    // OWASP A09: 内部 id をクライアント向け例外メッセージに露出しない
+                    .hasMessageNotContaining("id=");
 
             verify(inventoryService, never()).hasInventoryByProductId(any());
             verify(productRepository, never()).save(any());

--- a/backend/src/test/java/com/wms/master/service/ProductServiceTest.java
+++ b/backend/src/test/java/com/wms/master/service/ProductServiceTest.java
@@ -461,6 +461,35 @@ class ProductServiceTest {
             assertThatThrownBy(() -> productService.toggleActive(1L, false, 0))
                     .isInstanceOf(OptimisticLockConflictException.class);
         }
+
+        @Test
+        @DisplayName("[#470] no-op (既無効化) でも stale version は 409 を返す")
+        void toggleActive_noOpWithStaleVersion_throwsOptimisticLockConflict() {
+            Product existing = createProduct(1L, "P-001", "商品A", "AMBIENT");
+            existing.deactivate();
+            existing.setVersion(5);
+            when(productRepository.findById(1L)).thenReturn(Optional.of(existing));
+
+            assertThatThrownBy(() -> productService.toggleActive(1L, false, 3))
+                    .isInstanceOf(OptimisticLockConflictException.class);
+
+            verify(inventoryService, never()).hasInventoryByProductId(any());
+            verify(productRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("[#470] BR 違反かつ stale version の場合は 409 (OL) が 422 (BR) より優先される")
+        void toggleActive_brViolationAndStaleVersion_optimisticLockTakesPrecedence() {
+            Product existing = createProduct(1L, "P-001", "商品A", "AMBIENT");
+            existing.setVersion(5);
+            when(productRepository.findById(1L)).thenReturn(Optional.of(existing));
+
+            assertThatThrownBy(() -> productService.toggleActive(1L, false, 3))
+                    .isInstanceOf(OptimisticLockConflictException.class);
+
+            verify(inventoryService, never()).hasInventoryByProductId(any());
+            verify(productRepository, never()).save(any());
+        }
     }
 
     @Nested

--- a/backend/src/test/java/com/wms/master/service/WarehouseServiceTest.java
+++ b/backend/src/test/java/com/wms/master/service/WarehouseServiceTest.java
@@ -326,7 +326,10 @@ class WarehouseServiceTest {
             when(warehouseRepository.findById(1L)).thenReturn(Optional.of(existing));
 
             assertThatThrownBy(() -> warehouseService.toggleActive(1L, false, 3))
-                    .isInstanceOf(OptimisticLockConflictException.class);
+                    .isInstanceOf(OptimisticLockConflictException.class)
+                    .hasMessageContaining("他のユーザーによる更新が先行しました")
+                    // OWASP A09: 内部 id をクライアント向け例外メッセージに露出しない
+                    .hasMessageNotContaining("id=");
 
             verify(inventoryService, never()).hasInventoryByWarehouseId(any());
             verify(warehouseRepository, never()).save(any());

--- a/backend/src/test/java/com/wms/master/service/WarehouseServiceTest.java
+++ b/backend/src/test/java/com/wms/master/service/WarehouseServiceTest.java
@@ -316,6 +316,35 @@ class WarehouseServiceTest {
             assertThatThrownBy(() -> warehouseService.toggleActive(1L, false, 0))
                     .isInstanceOf(OptimisticLockConflictException.class);
         }
+
+        @Test
+        @DisplayName("[#470] no-op (既無効化) でも stale version は 409 を返す")
+        void toggleActive_noOpWithStaleVersion_throwsOptimisticLockConflict() {
+            Warehouse existing = createWarehouse(1L, "WARA", "東京DC");
+            existing.deactivate();
+            existing.setVersion(5);
+            when(warehouseRepository.findById(1L)).thenReturn(Optional.of(existing));
+
+            assertThatThrownBy(() -> warehouseService.toggleActive(1L, false, 3))
+                    .isInstanceOf(OptimisticLockConflictException.class);
+
+            verify(inventoryService, never()).hasInventoryByWarehouseId(any());
+            verify(warehouseRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("[#470] BR 違反かつ stale version の場合は 409 (OL) が 422 (BR) より優先される")
+        void toggleActive_brViolationAndStaleVersion_optimisticLockTakesPrecedence() {
+            Warehouse existing = createWarehouse(1L, "WARA", "東京DC");
+            existing.setVersion(5);
+            when(warehouseRepository.findById(1L)).thenReturn(Optional.of(existing));
+
+            assertThatThrownBy(() -> warehouseService.toggleActive(1L, false, 3))
+                    .isInstanceOf(OptimisticLockConflictException.class);
+
+            verify(inventoryService, never()).hasInventoryByWarehouseId(any());
+            verify(warehouseRepository, never()).save(any());
+        }
     }
 
     @Nested

--- a/backend/src/test/java/com/wms/system/service/UserServiceTest.java
+++ b/backend/src/test/java/com/wms/system/service/UserServiceTest.java
@@ -356,7 +356,10 @@ class UserServiceTest {
             when(userRepository.findById(1L)).thenReturn(Optional.of(existing));
 
             assertThatThrownBy(() -> userService.toggleActive(1L, false, 3, 99L))
-                    .isInstanceOf(OptimisticLockConflictException.class);
+                    .isInstanceOf(OptimisticLockConflictException.class)
+                    .hasMessageContaining("他のユーザーによる更新が先行しました")
+                    // OWASP A09: 内部 id をクライアント向け例外メッセージに露出しない
+                    .hasMessageNotContaining("id=");
 
             verify(userRepository, never()).save(any());
         }

--- a/backend/src/test/java/com/wms/system/service/UserServiceTest.java
+++ b/backend/src/test/java/com/wms/system/service/UserServiceTest.java
@@ -346,6 +346,34 @@ class UserServiceTest {
             assertThatThrownBy(() -> userService.toggleActive(1L, false, 0, 99L))
                     .isInstanceOf(OptimisticLockConflictException.class);
         }
+
+        @Test
+        @DisplayName("[#470] no-op (既無効化) でも stale version は 409 を返す")
+        void toggleActive_noOpWithStaleVersion_throwsOptimisticLockConflict() {
+            User existing = createUser(1L, "USR001", "山田太郎");
+            existing.setIsActive(false);
+            existing.setVersion(5);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(existing));
+
+            assertThatThrownBy(() -> userService.toggleActive(1L, false, 3, 99L))
+                    .isInstanceOf(OptimisticLockConflictException.class);
+
+            verify(userRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("[#470] BR 違反(自己無効化)かつ stale version の場合は 409 (OL) が 422 (BR) より優先される")
+        void toggleActive_brViolationAndStaleVersion_optimisticLockTakesPrecedence() {
+            User existing = createUser(1L, "USR001", "山田太郎");
+            existing.setVersion(5);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(existing));
+
+            // currentUserId=1L (自分自身) + isActive=false (自己無効化=BR違反) + version=3 (stale)
+            assertThatThrownBy(() -> userService.toggleActive(1L, false, 3, 1L))
+                    .isInstanceOf(OptimisticLockConflictException.class);
+
+            verify(userRepository, never()).save(any());
+        }
     }
 
     @Nested

--- a/docs/functional-design/API-05-master-user.md
+++ b/docs/functional-design/API-05-master-user.md
@@ -639,13 +639,16 @@ flowchart TD
     VALIDATE -->|OK| FETCH[SELECT FROM users WHERE id = :id]
 
     FETCH -->|存在しない| ERR_404[404 USER_NOT_FOUND]
-    FETCH -->|存在する| CHK_SELF{自分自身かつ\nisActive=false?}
-
-    CHK_SELF -->|Yes| ERR_422[422 CANNOT_DEACTIVATE_SELF]
-    CHK_SELF -->|No| CHK_VERSION{version一致?}
+    FETCH -->|存在する| CHK_VERSION{version一致?}
 
     CHK_VERSION -->|不一致| ERR_409[409 OPTIMISTIC_LOCK_CONFLICT]
-    CHK_VERSION -->|一致| UPDATE["UPDATE users SET<br/>- is_active = :isActive<br/>- version = version + 1<br/>- updated_by = ログイン中ユーザーID<br/>- updated_at = NOW<br/>WHERE id = :id AND version = :version"]
+    CHK_VERSION -->|一致| CHK_SAME{既に同じ状態?}
+
+    CHK_SAME -->|Yes| END_NOOP([200 OK + 現在のユーザーオブジェクト\n冪等性: 更新なし])
+    CHK_SAME -->|No| CHK_SELF{自分自身かつ\nisActive=false?}
+
+    CHK_SELF -->|Yes| ERR_422[422 CANNOT_DEACTIVATE_SELF]
+    CHK_SELF -->|No| UPDATE["UPDATE users SET<br/>- is_active = :isActive<br/>- version = version + 1<br/>- updated_by = ログイン中ユーザーID<br/>- updated_at = NOW<br/>WHERE id = :id AND version = :version"]
 
     UPDATE --> END([200 OK + 更新後ユーザーオブジェクト])
 ```


### PR DESCRIPTION
Closes #470

## Summary
- PartnerService#toggleActive (Issue #453) で導入した version 先行チェックパターンを他マスタ6サービスに横展開
- 対象: BuildingService, ProductService, AreaService, LocationService, WarehouseService, UserService
- CHECK_VERSION → CHECK_SAME → BR check の順序を統一（API設計書 §4 業務フロー準拠）
- `.equals()` → `Objects.equals()` (null安全) に統一
- 不要な `setVersion(version)` を削除（version事前チェック済み）
- 各サービスに2テスト追加（stale version + no-op、stale version + BR violation）

## Test coverage
### Backend (JaCoCo)
| クラス | C0 (LINE) | C1 (BRANCH) |
|--------|-----------|-------------|
| BuildingService | 100% | 100% |
| ProductService | 100% | 100% |
| AreaService | 100% | 100% |
| LocationService | 100% | 100% |
| WarehouseService | 100% | 100% |
| UserService | 100% | 100% |

## Test plan
- [x] BuildingService: stale version + no-op → 409
- [x] BuildingService: stale version + BR violation → 409 優先
- [x] ProductService: stale version + no-op → 409
- [x] ProductService: stale version + BR violation → 409 優先
- [x] AreaService: stale version + no-op → 409
- [x] AreaService: stale version + BR violation → 409 優先
- [x] LocationService: stale version + no-op → 409
- [x] LocationService: stale version + BR violation → 409 優先
- [x] WarehouseService: stale version + no-op → 409
- [x] WarehouseService: stale version + BR violation → 409 優先
- [x] UserService: stale version + no-op → 409
- [x] UserService: stale version + BR violation → 409 優先
- [x] 既存テスト全件パス (188件)
- [x] OWASP A09: 例外メッセージに内部ID非露出を検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)