### PR TITLE
test(inbound): 棚卸中ロケーション入庫・無効商品伝票作成の結合テスト追加

### DIFF
--- a/backend/src/test/java/com/wms/inbound/controller/InboundSlipIntegrationTest.java
+++ b/backend/src/test/java/com/wms/inbound/controller/InboundSlipIntegrationTest.java
@@ -161,6 +161,23 @@ class InboundSlipIntegrationTest extends IntegrationTestBase {
         }
 
         @Test
+        @DisplayName("無効商品を含む伝票作成 → 422")
+        void create_inactiveProduct_returns422() throws Exception {
+            try {
+                jdbcTemplate.update("UPDATE products SET is_active = false WHERE id = ?", productId);
+                String body = createSlipBody(productId, "PIECE", 100, null, null);
+
+                ResponseEntity<String> response = postJson(BASE_URL, body, adminHeaders);
+
+                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+                JsonNode json = parseJson(response.getBody());
+                assertThat(json.get("code").asText()).isEqualTo("PRODUCT_INACTIVE");
+            } finally {
+                jdbcTemplate.update("UPDATE products SET is_active = true WHERE id = ?", productId);
+            }
+        }
+
+        @Test
         @DisplayName("SC-INB-005: 必須フィールド未入力 → 400")
         void create_missingRequiredFields_returns400() throws Exception {
             String body = """
@@ -919,6 +936,31 @@ class InboundSlipIntegrationTest extends IntegrationTestBase {
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
             JsonNode json = parseJson(response.getBody());
             assertThat(json.get("code").asText()).isEqualTo("AREA_NOT_INBOUND");
+        }
+
+        @Test
+        @DisplayName("棚卸中ロケーションへの入庫 → 422")
+        void store_stocktakeLockedLocation_returns422() throws Exception {
+            Long slipId = createTestSlip();
+            confirmSlip(slipId);
+            Long lineId = getFirstLineId(slipId);
+            inspectLine(slipId, lineId, 100);
+
+            try {
+                jdbcTemplate.update("UPDATE locations SET is_stocktaking_locked = true WHERE id = ?", inboundLocationId);
+
+                String body = String.format("""
+                        { "lines": [{ "lineId": %d, "locationId": %d }] }
+                        """, lineId, inboundLocationId);
+
+                ResponseEntity<String> response = postJson(BASE_URL + "/" + slipId + "/store", body, adminHeaders);
+
+                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+                JsonNode json = parseJson(response.getBody());
+                assertThat(json.get("code").asText()).isEqualTo("LOCATION_STOCKTAKE_LOCKED");
+            } finally {
+                jdbcTemplate.update("UPDATE locations SET is_stocktaking_locked = false WHERE id = ?", inboundLocationId);
+            }
         }
 
         @Test

--- a/backend/src/test/java/com/wms/inbound/controller/InboundSlipIntegrationTest.java
+++ b/backend/src/test/java/com/wms/inbound/controller/InboundSlipIntegrationTest.java
@@ -177,6 +177,7 @@ class InboundSlipIntegrationTest extends IntegrationTestBase {
                 JsonNode json = parseJson(response.getBody());
                 assertThat(json.get("code").asText()).isEqualTo("PRODUCT_INACTIVE");
                 assertThat(json.has("traceId")).isTrue();
+                assertThat(json.get("message").asText()).doesNotContain("at com.wms");
             } finally {
                 jdbcTemplate.update("UPDATE products SET is_active = true WHERE id = ?", productId);
             }
@@ -964,6 +965,7 @@ class InboundSlipIntegrationTest extends IntegrationTestBase {
                 JsonNode json = parseJson(response.getBody());
                 assertThat(json.get("code").asText()).isEqualTo("LOCATION_STOCKTAKE_LOCKED");
                 assertThat(json.has("traceId")).isTrue();
+                assertThat(json.get("message").asText()).doesNotContain("at com.wms");
             } finally {
                 jdbcTemplate.update("UPDATE locations SET is_stocktaking_locked = false WHERE id = ?", inboundLocationId);
             }

--- a/backend/src/test/java/com/wms/inbound/controller/InboundSlipIntegrationTest.java
+++ b/backend/src/test/java/com/wms/inbound/controller/InboundSlipIntegrationTest.java
@@ -63,6 +63,10 @@ class InboundSlipIntegrationTest extends IntegrationTestBase {
         jdbcTemplate.update("DELETE FROM inbound_slip_lines");
         jdbcTemplate.update("DELETE FROM inbound_slips");
 
+        // テスト汚染防止: is_active / is_stocktaking_locked を必ず初期値に戻す（try/finally の二重安全網）
+        jdbcTemplate.update("UPDATE products SET is_active = true WHERE id = ?", productId);
+        jdbcTemplate.update("UPDATE locations SET is_stocktaking_locked = false WHERE id = ?", inboundLocationId);
+
         adminHeaders = loginAndGetHeaders(ADMIN_CODE, ADMIN_PASSWORD);
         plannedDate = LocalDate.now().plusDays(1).format(DateTimeFormatter.ISO_LOCAL_DATE);
     }
@@ -172,6 +176,7 @@ class InboundSlipIntegrationTest extends IntegrationTestBase {
                 assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
                 JsonNode json = parseJson(response.getBody());
                 assertThat(json.get("code").asText()).isEqualTo("PRODUCT_INACTIVE");
+                assertThat(json.has("traceId")).isTrue();
             } finally {
                 jdbcTemplate.update("UPDATE products SET is_active = true WHERE id = ?", productId);
             }
@@ -958,6 +963,7 @@ class InboundSlipIntegrationTest extends IntegrationTestBase {
                 assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
                 JsonNode json = parseJson(response.getBody());
                 assertThat(json.get("code").asText()).isEqualTo("LOCATION_STOCKTAKE_LOCKED");
+                assertThat(json.has("traceId")).isTrue();
             } finally {
                 jdbcTemplate.update("UPDATE locations SET is_stocktaking_locked = false WHERE id = ?", inboundLocationId);
             }


### PR DESCRIPTION
Closes #416

## Summary
- `InboundSlipIntegrationTest` に2つの結合テストを追加
  - F#14: 棚卸中ロケーション（`is_stocktaking_locked = true`）への入庫で `422 LOCATION_STOCKTAKE_LOCKED` を返すことを確認
  - F#15: 無効商品（`is_active = false`）を含む入荷伝票作成で `422 PRODUCT_INACTIVE` を返すことを確認

## Test coverage
### Backend (JaCoCo)
テスト追加のみ（既存サービスコードの変更なし）のため、カバレッジへの影響はありません。

## Test plan
- [x] 棚卸中ロケーションへの入庫で422エラーとなること
- [x] 無効商品を含む伝票作成で422エラーとなること
- [x] try-finallyで状態復元し、他テストに影響しないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)